### PR TITLE
Patches rq and pulpcore to heartbeat over 300s

### DIFF
--- a/packages/python-pulpcore/0001-Adjusts-worker-timeout-to-300-seconds.patch
+++ b/packages/python-pulpcore/0001-Adjusts-worker-timeout-to-300-seconds.patch
@@ -1,0 +1,14 @@
+diff --git a/pulpcore/tasking/constants.py b/pulpcore/tasking/constants.py
+index 3be25f9c0..e31cc8972 100644
+--- a/pulpcore/tasking/constants.py
++++ b/pulpcore/tasking/constants.py
+@@ -4,7 +4,7 @@ TASKING_CONSTANTS = SimpleNamespace(
+     # The name of resource manager entries in the workers table
+     RESOURCE_MANAGER_WORKER_NAME="resource-manager",
+     # The amount of time (in seconds) after which a worker process is considered missing.
+-    WORKER_TTL=30,
++    WORKER_TTL=300,
+     # The amount of time (in seconds) between checks
+     JOB_MONITORING_INTERVAL=5,
+     # The Redis key used to force-kill a job
+

--- a/packages/python-pulpcore/python-pulpcore.spec
+++ b/packages/python-pulpcore/python-pulpcore.spec
@@ -4,12 +4,13 @@
 
 Name:           python-%{pypi_name}
 Version:        3.7.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Pulp Django Application and Related Modules
 
 License:        GPLv2+
 URL:            https://pulpproject.org
 Source0:        https://files.pythonhosted.org/packages/source/p/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+Patch0:         0001-Adjusts-worker-timeout-to-300-seconds.patch
 BuildArch:      noarch
 
 BuildRequires:  python%{python3_pkgversion}-devel
@@ -137,7 +138,7 @@ Using Pulp you can:
 - Promote content through different repos in an organized way
 
 %prep
-%autosetup -n %{pypi_name}-%{version}
+%autosetup -p1 -n %{pypi_name}-%{version}
 # Remove bundled egg-info
 rm -rf %{pypi_name}.egg-info
 
@@ -167,6 +168,9 @@ done
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Wed Mar 03 2021 Brian Bouterse - 3.7.3-2
+- Increase Pulp worker timeout to 300 seconds
+
 * Tue Nov 03 2020 Evgeni Golov 3.7.3-1
 - Update to 3.7.3
 

--- a/packages/python-rq/0001-Have-hearbeats-occur-more-frequently.patch
+++ b/packages/python-rq/0001-Have-hearbeats-occur-more-frequently.patch
@@ -1,0 +1,31 @@
+From a233dd13494670f3cf13ea41fc66893aba1c3766 Mon Sep 17 00:00:00 2001
+From: Brian Bouterse <bmbouter@redhat.com>
+Date: Tue, 2 Mar 2021 16:33:10 -0500
+Subject: [PATCH] Have hearbeats occur more frequently
+
+Exactly one heartbeat occurs and it's hardcoded to 15 seconds before the
+`default_worker_ttl`. For reliability heartbeats should occur more
+frequently, 3-times within each TTL with an interarrival time of
+`default_worker_ttl` / 3.
+
+fixes #1426
+---
+ rq/worker.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rq/worker.py b/rq/worker.py
+index 8aa07bd..4cd8a69 100644
+--- a/rq/worker.py
++++ b/rq/worker.py
+@@ -568,7 +568,7 @@ class Worker(object):
+                         self.log.info('Worker %s: stopping on request', self.key)
+                         break
+ 
+-                    timeout = None if burst else max(1, self.default_worker_ttl - 15)
++                    timeout = None if burst else max(1, int(self.default_worker_ttl / 3))
+
+                     result = self.dequeue_job_and_maintain_ttl(timeout)
+                     if result is None:
+-- 
+2.26.2
+

--- a/packages/python-rq/python-rq.spec
+++ b/packages/python-rq/python-rq.spec
@@ -3,12 +3,13 @@
 
 Name:           python-%{pypi_name}
 Version:        1.5.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        RQ is a simple, lightweight, library for creating background jobs, and processing them
 
 License:        BSD
 URL:            https://github.com/nvie/rq/
 Source0:        https://files.pythonhosted.org/packages/source/r/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+Patch0:         0001-Have-hearbeats-occur-more-frequently.patch
 BuildArch:      noarch
 
 BuildRequires:  python3-devel
@@ -28,7 +29,7 @@ Requires:       python3-setuptools
 %{summary}
 
 %prep
-%autosetup -n %{pypi_name}-%{version}
+%autosetup -p1 -n %{pypi_name}-%{version}
 # Remove bundled egg-info
 rm -rf %{pypi_name}.egg-info
 
@@ -48,6 +49,9 @@ rm -rf %{pypi_name}.egg-info
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Wed Mar 03 2021 Brian Bouterse - 1.5.2-2
+- Have heartbeats occur more frequently within the worker TTL
+
 * Thu Sep 10 2020 Evgeni Golov 1.5.2-1
 - Update to 1.5.2
 


### PR DESCRIPTION
* pulpcore's worker timeout is adjusted to 300 seconds before it is
  considered missing
* rq is adjusted so that more heartbeats will occur during the worker
  timeout period