### PR TITLE
Update pulp_deb to 2.9.2 (pulpcore 3.7 repo)

### DIFF
--- a/packages/python-pulp-deb/pulp-deb-2.7.0.tar.gz
+++ b/packages/python-pulp-deb/pulp-deb-2.7.0.tar.gz
@@ -1,1 +1,0 @@
-../../.git/annex/objects/wK/J8/SHA256E-s48082--2d0f920cbc22af05ff08d4160643a37377e73e6469d9f30b8b024d7405cfdbcf.tar.gz/SHA256E-s48082--2d0f920cbc22af05ff08d4160643a37377e73e6469d9f30b8b024d7405cfdbcf.tar.gz

--- a/packages/python-pulp-deb/pulp-deb-2.9.2.tar.gz
+++ b/packages/python-pulp-deb/pulp-deb-2.9.2.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/F9/gG/SHA256E-s53994--00104bd46e9eb10a33b5520b29ae1a0bee8d1caf93af1af8b629a976ffa341a6.tar.gz/SHA256E-s53994--00104bd46e9eb10a33b5520b29ae1a0bee8d1caf93af1af8b629a976ffa341a6.tar.gz

--- a/packages/python-pulp-deb/python-pulp-deb.spec
+++ b/packages/python-pulp-deb/python-pulp-deb.spec
@@ -2,7 +2,7 @@
 %global pypi_name pulp-deb
 
 Name:           python-%{pypi_name}
-Version:        2.7.0
+Version:        2.9.2
 Release:        1%{?dist}
 Summary:        pulp-deb plugin for the Pulp Project
 
@@ -21,7 +21,7 @@ BuildRequires:  python3-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python3-%{pypi_name}}
 Requires:       python3-debian >= 0.1.36
-Requires:       python3-pulpcore < 3.9
+Requires:       python3-pulpcore < 3.11
 Requires:       python3-pulpcore >= 3.7
 Requires:       python3-setuptools
 
@@ -46,6 +46,9 @@ rm -rf %{pypi_name}.egg-info
 %{python3_sitelib}/pulp_deb-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Wed May 26 2021 Quirin Pamp - 2.9.2-1
+- Release python-pulp-deb 2.9.2
+
 * Wed Sep 30 2020 Evgeni Golov - 2.7.0-1
 - Release python-pulp-deb 2.7.0
 


### PR DESCRIPTION
Needs to be coordinated with:
- https://github.com/theforeman/foreman-packaging/pull/6588
- https://github.com/Katello/katello/pull/9329
- The Katello 3.18.4 release