### PR TITLE
Update python-pulp-container to 2.2.2 

### DIFF
--- a/packages/python-pulp-container/pulp-container-2.2.1.tar.gz
+++ b/packages/python-pulp-container/pulp-container-2.2.1.tar.gz
@@ -1,1 +1,0 @@
-../../.git/annex/objects/Xv/xp/SHA256E-s74497--0f4a89610219fb6290a33fb851875ed8f74ebc31e5b344180eecdb70b597f6fa.tar.gz/SHA256E-s74497--0f4a89610219fb6290a33fb851875ed8f74ebc31e5b344180eecdb70b597f6fa.tar.gz

--- a/packages/python-pulp-container/pulp-container-2.2.2.tar.gz
+++ b/packages/python-pulp-container/pulp-container-2.2.2.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/f7/zQ/SHA256E-s75241--3b82f41fa3ff51b50eeea724b2459a30e044e4bd3a6a3d9bc478aec6393e52bd.tar.gz/SHA256E-s75241--3b82f41fa3ff51b50eeea724b2459a30e044e4bd3a6a3d9bc478aec6393e52bd.tar.gz

--- a/packages/python-pulp-container/python-pulp-container.spec
+++ b/packages/python-pulp-container/python-pulp-container.spec
@@ -2,7 +2,7 @@
 %global pypi_name pulp-container
 
 Name:           python-%{pypi_name}
-Version:        2.2.1
+Version:        2.2.2
 Release:        1%{?dist}
 Summary:        Container plugin for the Pulp Project
 
@@ -61,6 +61,9 @@ rm -rf %{pypi_name}.egg-info
 %{python3_sitelib}/pulp_container-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Thu May 27 2021 Odilon Sousa <osousa@redhat.com> - 2.2.2-1
+- Release python-pulp-container 2.2.2
+
 * Thu Mar 18 2021 Justin Sherrill <jsherril@redhat.com> 2.2.1-1
 - update to 2.2.1
 


### PR DESCRIPTION
Bumping the package version from 2.2.1 to 2.2.2 for rpm/3.9. 
