### PR TITLE
Add mock configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+SRPMs/
+mock_builds/

--- a/mock/el7-nonscl.cfg
+++ b/mock/el7-nonscl.cfg
@@ -1,0 +1,41 @@
+config_opts['root'] = 'pulpcore-el7-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz'
+config_opts['chroot_additional_packages'] = 'yum vim'
+config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
+# beware RHEL use 7Server or 7Client
+config_opts['releasever'] = '7'
+config_opts['package_manager'] = 'yum'
+
+config_opts['yum.conf'] = """
+[main]
+cachedir=/var/cache/yum
+debuglevel=1
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+
+# repos
+[base]
+name=BaseOS
+enabled=1
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os
+failovermethod=priority
+
+[updates]
+name=updates
+enabled=1
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=updates
+failovermethod=priority
+
+[pulpcore]
+name=pulpcore
+enabled=1
+baseurl=https://yum.theforeman.org/pulpcore/3.14/el7/x86_64/
+"""

--- a/mock/el7-nonscl.cfg
+++ b/mock/el7-nonscl.cfg
@@ -37,5 +37,5 @@ failovermethod=priority
 [pulpcore]
 name=pulpcore
 enabled=1
-baseurl=https://yum.theforeman.org/pulpcore/3.14/el7/x86_64/
+baseurl=https://yum.theforeman.org/pulpcore/3.15/el7/x86_64/
 """

--- a/mock/el7-scl.cfg
+++ b/mock/el7-scl.cfg
@@ -40,5 +40,5 @@ baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/rh/
 
 [pulpcore]
 name=pulpcore
-baseurl=https://yum.theforeman.org/pulpcore/3.14/el7/x86_64/
+baseurl=https://yum.theforeman.org/pulpcore/3.15/el7/x86_64/
 """

--- a/mock/el7-scl.cfg
+++ b/mock/el7-scl.cfg
@@ -1,0 +1,44 @@
+config_opts['root'] = 'pulpcore-scl-el7-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz scl-utils-build rh-python38-scldevel rh-python38-python-rpm-macros'
+config_opts['chroot_additional_packages'] = 'yum vim'
+config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
+# beware RHEL use 7Server or 7Client
+config_opts['releasever'] = '7'
+config_opts['package_manager'] = 'yum'
+
+config_opts['yum.conf'] = """
+[main]
+cachedir=/var/cache/yum
+debuglevel=1
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+
+# repos
+[base]
+name=BaseOS
+enabled=1
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os
+failovermethod=priority
+
+[updates]
+name=updates
+enabled=1
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=updates
+failovermethod=priority
+
+[sclo-rh]
+name=sclo-rh
+baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/rh/
+
+[pulpcore]
+name=pulpcore
+baseurl=https://yum.theforeman.org/pulpcore/3.14/el7/x86_64/
+"""

--- a/mock/el8.cfg
+++ b/mock/el8.cfg
@@ -63,5 +63,5 @@ module_hotfixes=1
 
 [pulpcore]
 name=pulpcore
-baseurl=https://yum.theforeman.org/pulpcore/3.14/el8/x86_64/
+baseurl=https://yum.theforeman.org/pulpcore/3.15/el8/x86_64/
 """

--- a/mock/el8.cfg
+++ b/mock/el8.cfg
@@ -1,0 +1,67 @@
+config_opts['root'] = 'pulpcore-el8-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+
+config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ redhat-rpm-config redhat-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep vim python38-rpm-macros'
+config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '8'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['bootstrap_image'] = 'centos:8'
+
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+protected_packages=
+module_platform_id=platform:el8
+
+[BaseOS]
+name=CentOS-$releasever - Base
+mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=BaseOS&infra=$infra
+failovermethod=priority
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgcheck=1
+skip_if_unavailable=False
+
+[PowerTools]
+name=CentOS-$releasever - PowerTools
+mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=PowerTools&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/PowerTools/$basearch/os/
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
+[extras]
+name=CentOS-$releasever - Extras
+mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=extras&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
+[koji-non-modular]
+name=koji-non-modular
+baseurl=http://koji.katello.org/kojifiles/releases/split/yum/koji-modules/koji/staged/x86_64/RHEL-8-001-mod/non_modular/
+module_hotfixes=1
+
+[koji-python-38]
+name=koji-python-38
+baseurl=http://koji.katello.org/kojifiles/releases/split/yum/koji-modules/koji/staged/x86_64/RHEL-8-001-mod/python38:3.8/
+module_hotfixes=1
+
+[pulpcore]
+name=pulpcore
+baseurl=https://yum.theforeman.org/pulpcore/3.14/el8/x86_64/
+"""


### PR DESCRIPTION
@evgeni @Odilhao This adds mock configs for EL7 nonscl, SCL and EL8. This should provide a starting place to be able to update python specs to have scl_prefix options in them and then test builds. The syntax using obal is:

```
obal mock <package> --config mock/el7-scl.cfg
```