### PR TITLE
Depend on mailcap for mime.types

### DIFF
--- a/packages/python-aiohttp/python-aiohttp.spec
+++ b/packages/python-aiohttp/python-aiohttp.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        3.7.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Async http client/server framework (asyncio)
 
 License:        Apache 2
@@ -32,6 +32,9 @@ Requires:       python%{python3_pkgversion}-typing-extensions >= 3.6.5
 Requires:       python%{python3_pkgversion}-yarl < 2.0
 Requires:       python%{python3_pkgversion}-yarl >= 1.0
 
+# aiohttp depends on stdlib's mimetypes which reads /etc/mime.types
+Requires:       /etc/mime.types
+
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
 
@@ -53,6 +56,9 @@ rm -rf %{pypi_name}.egg-info
 %{python3_sitearch}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Tue Aug 24 2021 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.7.4-2
+- Depend on /etc/mime.types
+
 * Fri Mar 19 2021 Evgeni Golov 3.7.4-1
 - Update to 3.7.4
 


### PR DESCRIPTION
aiohttp imports stdlib's mimetypes which attempts to read various locations where mime.types can be. In Python 3.6 this is:

```python
knownfiles = [
    "/etc/mime.types",
    "/etc/httpd/mime.types",                    # Mac OS X
    "/etc/httpd/conf/mime.types",               # Apache
    "/etc/apache/mime.types",                   # Apache 1
    "/etc/apache2/mime.types",                  # Apache 2
    "/usr/local/etc/httpd/conf/mime.types",
    "/usr/local/lib/netscape/mime.types",
    "/usr/local/etc/httpd/conf/mime.types",     # Apache 1.2
    "/usr/local/etc/mime.types",                # Apache 1.3
    ]
```

Until a file is found, the next location is tried. On EL7 and EL8 the mailcap package provides `/etc/mime.types`.

This also solves a SELinux denial where `pulpcore_server_t` tries to read files from `/etc/httpd`. Since it's lower on the list than `/etc/mime.types`, this should be resolved.

This was found in https://github.com/pulp/pulpcore-selinux/pull/37 and has more information.