### PR TITLE
set scl in the package manifest

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -39,8 +39,10 @@ repoclosures:
 
 pulpcore_packages:
   vars:
+    scl: 'tfm-pulpcore'
     koji_tags:
       - name: pulpcore-{{ pulpcore_version }}-el7
+        scl: 'tfm-pulpcore'
         dist: '.el7'
       - name: pulpcore-{{ pulpcore_version }}-el8
         dist: '.el8'


### PR DESCRIPTION
otherwise obal is confused when checking existing builds