### PR TITLE
exclude django-admin.py

### DIFF
--- a/packages/python-django/python-django.spec
+++ b/packages/python-django/python-django.spec
@@ -7,7 +7,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        3.2.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A high-level Python Web framework that encourages rapid development and clean, pragmatic design
 
 License:        BSD-3-Clause
@@ -71,12 +71,15 @@ set -ex
 %license LICENSE LICENSE.python django/contrib/admin/static/admin/css/vendor/select2/LICENSE-SELECT2.md django/contrib/admin/static/admin/fonts/LICENSE.txt django/contrib/admin/static/admin/img/LICENSE django/contrib/admin/static/admin/js/vendor/jquery/LICENSE.txt django/contrib/admin/static/admin/js/vendor/select2/LICENSE.md django/contrib/admin/static/admin/js/vendor/xregexp/LICENSE.txt django/contrib/gis/gdal/LICENSE django/contrib/gis/geos/LICENSE django/dispatch/license.txt docs/_theme/djangodocs/static/fontawesome/LICENSE.txt
 %doc README.rst django/contrib/admin/static/admin/fonts/README.txt django/contrib/admin/static/admin/img/README.txt docs/README.rst docs/_theme/djangodocs/static/fontawesome/README.md extras/README.TXT tests/README.rst
 %{_bindir}/django-admin
-%{_bindir}/django-admin.py
+%exclude %{_bindir}/django-admin.py
 %{python3_sitelib}/django
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Fri Sep 10 2021 Evgeni Golov 3.2.7-2
+- Exclude django-admin.py again, we never shipped that.
+
 * Wed Sep 08 2021 Evgeni Golov 3.2.7-1
 - Update to 3.2.7
 


### PR DESCRIPTION
it's deprecated, we never shipped it in the past

and it makes the pkg depend on /usr/bin/python3 instead of "the right python"