### PR TITLE
Depend on mailcap for mime.types

### DIFF
--- a/packages/python-aiohttp/python-aiohttp.spec
+++ b/packages/python-aiohttp/python-aiohttp.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.7.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Async http client/server framework (asyncio)
 
 License:        Apache 2
@@ -37,6 +37,8 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-typing-extensions >= 3
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-yarl < 2.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-yarl >= 1.0
 
+# aiohttp depends on stdlib's mimetypes which reads /etc/mime.types
+Requires:       /etc/mime.types
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -73,6 +75,9 @@ set -ex
 
 
 %changelog
+* Mon Sep 27 2021 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl> - 3.7.4-3
+- Depend on /etc/mime.types
+
 * Mon Sep 06 2021 Evgeni Golov - 3.7.4-2
 - Build against Python 3.8
 


### PR DESCRIPTION
aiohttp imports stdlib's mimetypes which attempts to read various locations where mime.types can be. In Python 3.6 this is:

```python
knownfiles = [
    "/etc/mime.types",
    "/etc/httpd/mime.types",                    # Mac OS X
    "/etc/httpd/conf/mime.types",               # Apache
    "/etc/apache/mime.types",                   # Apache 1
    "/etc/apache2/mime.types",                  # Apache 2
    "/usr/local/etc/httpd/conf/mime.types",
    "/usr/local/lib/netscape/mime.types",
    "/usr/local/etc/httpd/conf/mime.types",     # Apache 1.2
    "/usr/local/etc/mime.types",                # Apache 1.3
    ]
```

Until a file is found, the next location is tried. On EL7 and EL8 the mailcap package provides /etc/mime.types.

This also solves a SELinux denial where pulpcore_server_t tries to read files from /etc/httpd. Since it's lower on the list than /etc/mime.types, this should be resolved.

This is https://github.com/theforeman/pulpcore-packaging/pull/215 but for 3.15.