### PR TITLE
Also obsolete python3-pulpcore on EL7

### DIFF
--- a/packages/python-pulpcore/python-pulpcore.spec
+++ b/packages/python-pulpcore/python-pulpcore.spec
@@ -10,7 +10,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.15.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Pulp Django Application and Related Modules
 
 License:        GPLv2+
@@ -93,9 +93,8 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools >= 39.2.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-whitenoise < 5.4.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-whitenoise >= 5.0.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-yarl > 1.0.0
-%if 0%{?!scl:1}
+
 Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
-%endif
 
 Provides:       %{pypi_name} = %{version}
 
@@ -176,6 +175,9 @@ done
 
 
 %changelog
+* Tue Oct 26 2021 Evgeni Golov - 3.15.2-4
+- Also obsolete python3-pulpcore on EL7
+
 * Wed Oct 20 2021 Evgeni Golov - 3.15.2-3
 - Add provides for 'pulpcore'
 


### PR DESCRIPTION
The following files conflict:

    /usr/libexec/pulpcore/gunicorn
    /usr/libexec/pulpcore/rq
    /usr/bin/pulp-content
    /usr/bin/pulpcore-manager
    /usr/libexec/pulpcore/pulpcore-worker