### PR TITLE
Obsolete non-SCL Python 3 packages on EL7

### DIFF
--- a/packages/createrepo_c/createrepo_c.spec
+++ b/packages/createrepo_c/createrepo_c.spec
@@ -36,7 +36,7 @@
 Summary:        Creates a common metadata repository
 Name:           createrepo_c
 Version:        0.17.6
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2+
 URL:            https://github.com/rpm-software-management/createrepo_c
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
@@ -101,6 +101,9 @@ Summary:        Python 3 bindings for the createrepo_c library
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}
 BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-devel
 Requires:       %{name}-libs = %{version}-%{release}
+%if 0%{?scl:1}
+Obsoletes:      python3-%{name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{name}
 Python 3 bindings for the createrepo_c library.
@@ -199,6 +202,9 @@ ln -sr %{buildroot}%{_bindir}/modifyrepo_c %{buildroot}%{_bindir}/modifyrepo
 %{python3_sitearch}/%{name}-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Tue Oct 26 2021 Evgeni Golov - 0.17.6-3
+- Obsolete non-SCL Python 3 packages on EL7
+
 * Tue Oct 05 2021 Evgeni Golov - 0.17.6-2
 - Build against Python 3.8
 

--- a/packages/libcomps/libcomps.spec
+++ b/packages/libcomps/libcomps.spec
@@ -32,7 +32,7 @@
 
 Name:           libcomps
 Version:        0.1.15
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Comps XML file manipulation library
 
 License:        GPLv2+
@@ -105,6 +105,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-devel
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 Obsoletes:      %{?scl_prefix}platform-python-%{name} < %{version}-%{release}
+%if 0%{?scl:1}
+Obsoletes:      python3-%{name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{name}
 Python3 bindings for libcomps library.
@@ -275,6 +278,9 @@ popd
 %endif
 
 %changelog
+* Tue Oct 26 2021 Evgeni Golov - 0.1.15-4
+- Obsolete non-SCL Python 3 packages on EL7
+
 * Wed Oct 13 2021 Evgeni Golov - 0.1.15-3
 - Also build libcomps against Python 3.6 on EL8
 

--- a/packages/libsolv/libsolv.spec
+++ b/packages/libsolv/libsolv.spec
@@ -38,7 +38,7 @@
 
 Name:           lib%{libname}
 Version:        0.7.20
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Package dependency solver
 
 License:        BSD
@@ -146,6 +146,9 @@ Summary:        Python bindings for the %{name} library
 BuildRequires:  swig
 BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-devel
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+%if 0%{?scl:1}
+Obsoletes:      python3-%{libname} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{libname}
 Python bindings for the %{name} library.
@@ -305,6 +308,9 @@ set -ex
 %endif
 
 %changelog
+* Tue Oct 26 2021 Evgeni Golov - 0.7.20-3
+- Obsolete non-SCL Python 3 packages on EL7
+
 * Tue Sep 28 2021 Evgeni Golov - 0.7.20-2
 - Build against Python 3.8
 


### PR DESCRIPTION
We don't build them, and leaving them on the system makes upgrades harder