### PR TITLE
Remove python 3.6 package obsolete and exclude files in bin directory

### DIFF
--- a/packages/python-commonmark/python-commonmark.spec
+++ b/packages/python-commonmark/python-commonmark.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.9.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Python parser for the CommonMark Markdown spec
 
 License:        BSD-3-Clause
@@ -28,9 +28,6 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-future >= 0.14.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
-%if 0%{?!scl:1}
-Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
-%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -63,12 +60,15 @@ set -ex
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %license LICENSE
 %doc README.rst
-%{_bindir}/cmark
+%exclude %{_bindir}/cmark
 %{python3_sitelib}/%{pypi_name}
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Fri Nov 05 2021 Satoe Imaishi - 0.9.1-4
+- Don't obsolete python 3.6 package and exclude files in bin
+
 * Wed Sep 29 2021 Evgeni Golov - 0.9.1-3
 - Obsolete the old Python 3.6 package for smooth upgrade
 

--- a/packages/python-jsonschema/python-jsonschema.spec
+++ b/packages/python-jsonschema/python-jsonschema.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.2.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        An implementation of JSON Schema validation for Python
 
 License:        MIT
@@ -31,9 +31,6 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-importlib-metadata
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-pyrsistent >= 0.14.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six >= 1.11.0
-%if 0%{?!scl:1}
-Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
-%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -66,12 +63,15 @@ set -ex
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %license json/LICENSE
 %doc json/README.md README.rst
-%{_bindir}/jsonschema
+%exclude %{_bindir}/jsonschema
 %{python3_sitelib}/%{pypi_name}
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Fri Nov 05 2021 Satoe Imaishi - 3.2.0-7
+- Don't obsolete python 3.6 package and exclude files in bin
+
 * Wed Sep 29 2021 Evgeni Golov - 3.2.0-6
 - Obsolete the old Python 3.6 package for smooth upgrade
 

--- a/packages/python-markdown/python-markdown.spec
+++ b/packages/python-markdown/python-markdown.spec
@@ -7,7 +7,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        3.3.4
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Python implementation of Markdown
 
 License:        BSD License
@@ -29,9 +29,6 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-importlib-metadata
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
-%if 0%{?!scl:1}
-Obsoletes:      python3-%{srcname} < %{version}-%{release}
-%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -64,12 +61,15 @@ set -ex
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 %license LICENSE.md
 %doc README.md
-%{_bindir}/markdown_py
+%exclude %{_bindir}/markdown_py
 %{python3_sitelib}/markdown
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Fri Nov 05 2021 Satoe Imaishi - 3.3.4-4
+- Don't obsolete python 3.6 package and exclude files in bin
+
 * Wed Sep 29 2021 Evgeni Golov - 3.3.4-3
 - Obsolete the old Python 3.6 package for smooth upgrade
 

--- a/packages/python-odfpy/python-odfpy.spec
+++ b/packages/python-odfpy/python-odfpy.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.4.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Python API and tools to manipulate OpenDocument files
 
 License:        GPLv2+ or Apache-2.0
@@ -26,9 +26,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-defusedxml
-%if 0%{?!scl:1}
-Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
-%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -61,17 +58,17 @@ set -ex
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %license APACHE-LICENSE-2.0.txt GPL-LICENSE-2.txt
 %doc contrib/ODFFile/README.txt README.md
-%{_bindir}/csv2ods
-%{_bindir}/mailodf
-%{_bindir}/odf2mht
-%{_bindir}/odf2xhtml
-%{_bindir}/odf2xml
-%{_bindir}/odfimgimport
-%{_bindir}/odflint
-%{_bindir}/odfmeta
-%{_bindir}/odfoutline
-%{_bindir}/odfuserfield
-%{_bindir}/xml2odf
+%exclude %{_bindir}/csv2ods
+%exclude %{_bindir}/mailodf
+%exclude %{_bindir}/odf2mht
+%exclude %{_bindir}/odf2xhtml
+%exclude %{_bindir}/odf2xml
+%exclude %{_bindir}/odfimgimport
+%exclude %{_bindir}/odflint
+%exclude %{_bindir}/odfmeta
+%exclude %{_bindir}/odfoutline
+%exclude %{_bindir}/odfuserfield
+%exclude %{_bindir}/xml2odf
 %{_mandir}/*/csv2ods*
 %{_mandir}/*/mailodf*
 %{_mandir}/*/odf2mht*
@@ -88,6 +85,9 @@ set -ex
 
 
 %changelog
+* Fri Nov 05 2021 Satoe Imaishi - 1.4.1-5
+- Don't obsolete python 3.6 package and exclude files in bin
+
 * Wed Sep 29 2021 Evgeni Golov - 1.4.1-4
 - Obsolete the old Python 3.6 package for smooth upgrade
 

--- a/packages/python-pycodestyle/python-pycodestyle.spec
+++ b/packages/python-pycodestyle/python-pycodestyle.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.7.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Python style guide checker
 
 License:        Expat license
@@ -26,9 +26,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
-%if 0%{?!scl:1}
-Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
-%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -61,13 +58,16 @@ set -ex
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %license LICENSE
 %doc README.rst
-%{_bindir}/pycodestyle
+%exclude %{_bindir}/pycodestyle
 %{python3_sitelib}/__pycache__/%{pypi_name}.*
 %{python3_sitelib}/%{pypi_name}.py
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Fri Nov 05 2021 Satoe Imaishi - 2.7.0-4
+- Don't obsolete python 3.6 package and exclude files in bin
+
 * Wed Sep 29 2021 Evgeni Golov - 2.7.0-3
 - Obsolete the old Python 3.6 package for smooth upgrade
 

--- a/packages/python-pyflakes/python-pyflakes.spec
+++ b/packages/python-pyflakes/python-pyflakes.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.3.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        passive checker of Python programs
 
 License:        MIT
@@ -26,9 +26,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
-%if 0%{?!scl:1}
-Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
-%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -61,12 +58,15 @@ set -ex
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %license LICENSE
 %doc README.rst
-%{_bindir}/pyflakes
+%exclude %{_bindir}/pyflakes
 %{python3_sitelib}/%{pypi_name}
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Fri Nov 05 2021 Satoe Imaishi - 2.3.1-4
+- Don't obsolete python 3.6 package and exclude files in bin
+
 * Wed Sep 29 2021 Evgeni Golov - 2.3.1-3
 - Obsolete the old Python 3.6 package for smooth upgrade
 

--- a/packages/python-pygments/python-pygments.spec
+++ b/packages/python-pygments/python-pygments.spec
@@ -7,7 +7,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        2.8.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Pygments is a syntax highlighting package written in Python
 
 License:        BSD License
@@ -28,9 +28,6 @@ BuildArch:      noarch
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
-%if 0%{?!scl:1}
-Obsoletes:      python3-%{srcname} < %{version}-%{release}
-%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -63,12 +60,15 @@ set -ex
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 %license LICENSE
 %doc README.rst
-%{_bindir}/pygmentize
+%exclude %{_bindir}/pygmentize
 %{python3_sitelib}/pygments
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Fri Nov 05 2021 Satoe Imaishi - 2.8.1-4
+- Don't obsolete python 3.6 package and exclude files in bin
+
 * Wed Sep 29 2021 Evgeni Golov - 2.8.1-3
 - Obsolete the old Python 3.6 package for smooth upgrade
 

--- a/packages/python-pyjwkest/python-pyjwkest.spec
+++ b/packages/python-pyjwkest/python-pyjwkest.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.4.2
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Python implementation of JWT, JWE, JWS and JWK
 
 License:        Apache 2.0
@@ -29,9 +29,6 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-future
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-pycryptodomex
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-requests
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six
-%if 0%{?!scl:1}
-Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
-%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -63,18 +60,21 @@ set -ex
 
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %doc README.rst
-%{_bindir}/gen_symkey.py
-%{_bindir}/jwdecrypt.py
-%{_bindir}/jwenc.py
-%{_bindir}/jwk_create.py
-%{_bindir}/jwk_export.py
-%{_bindir}/jwkutil.py
-%{_bindir}/peek.py
+%exclude %{_bindir}/gen_symkey.py
+%exclude %{_bindir}/jwdecrypt.py
+%exclude %{_bindir}/jwenc.py
+%exclude %{_bindir}/jwk_create.py
+%exclude %{_bindir}/jwk_export.py
+%exclude %{_bindir}/jwkutil.py
+%exclude %{_bindir}/peek.py
 %{python3_sitelib}/jwkest
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Fri Nov 05 2021 Satoe Imaishi - 1.4.2-5
+- Don't obsolete python 3.6 package and exclude files in bin
+
 * Wed Sep 29 2021 Evgeni Golov - 1.4.2-4
 - Obsolete the old Python 3.6 package for smooth upgrade
 

--- a/packages/python-pyjwt/python-pyjwt.spec
+++ b/packages/python-pyjwt/python-pyjwt.spec
@@ -7,7 +7,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        1.7.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        JSON Web Token implementation in Python
 
 License:        MIT
@@ -30,9 +30,6 @@ Provides:       %{?scl_prefix}python%{python3_pkgversion}-jwt = %{version}-%{rel
 Obsoletes:      %{?scl_prefix}python%{python3_pkgversion}-jwt < %{version}-%{release}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-cryptography >= 1.4
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
-%if 0%{?!scl:1}
-Obsoletes:      python3-%{srcname} < %{version}-%{release}
-%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -65,12 +62,15 @@ set -ex
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 %license LICENSE
 %doc README.rst
-%{_bindir}/pyjwt
+%exclude %{_bindir}/pyjwt
 %{python3_sitelib}/jwt
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Fri Nov 05 2021 Satoe Imaishi - 1.7.1-7
+- Don't obsolete python 3.6 package and exclude files in bin
+
 * Wed Sep 29 2021 Evgeni Golov - 1.7.1-6
 - Obsolete the old Python 3.6 package for smooth upgrade
 

--- a/packages/python-sqlparse/python-sqlparse.spec
+++ b/packages/python-sqlparse/python-sqlparse.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.4.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A non-validating SQL parser
 
 License:        BSD-3-Clause
@@ -26,9 +26,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
-%if 0%{?!scl:1}
-Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
-%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -61,12 +58,15 @@ set -ex
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %license LICENSE docs/source/license.rst
 %doc README.rst
-%{_bindir}/sqlformat
+%exclude %{_bindir}/sqlformat
 %{python3_sitelib}/%{pypi_name}
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Fri Nov 05 2021 Satoe Imaishi - 0.4.1-4
+- Don't obsolete python 3.6 package and exclude files in bin
+
 * Wed Sep 29 2021 Evgeni Golov - 0.4.1-3
 - Obsolete the old Python 3.6 package for smooth upgrade
 

--- a/packages/python-xlrd/python-xlrd.spec
+++ b/packages/python-xlrd/python-xlrd.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.0.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Library for developers to extract data from Microsoft Excel (tm)
 
 License:        BSD
@@ -25,9 +25,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
-%if 0%{?!scl:1}
-Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
-%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -60,12 +57,15 @@ set -ex
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %license LICENSE
 %doc README.rst
-%{_bindir}/runxlrd.py
+%exclude %{_bindir}/runxlrd.py
 %{python3_sitelib}/%{pypi_name}
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Fri Nov 05 2021 Satoe Imaishi - 2.0.1-4
+- Don't obsolete python 3.6 package and exclude files in bin
+
 * Wed Sep 29 2021 Evgeni Golov - 2.0.1-3
 - Obsolete the old Python 3.6 package for smooth upgrade
 


### PR DESCRIPTION
Made the changes only to packages that caused conflicts upgrading galaxy, but excluded: ansible-builder, dynaconf, flake8, gunicorn, pulpcore and rq