### PR TITLE
adjust galaxy-importer and ansible-lint dependencies for ansible-core in EL8

### DIFF
--- a/packages/ansible-lint/ansible-lint.spec
+++ b/packages/ansible-lint/ansible-lint.spec
@@ -3,7 +3,7 @@
 
 Name:           %{pypi_name}
 Version:        5.0.8
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Checks playbooks for practices and behaviour that could potentially be improved
 
 License:        MIT
@@ -17,7 +17,10 @@ BuildRequires:  python%{python3_pkgversion}-setuptools-scm >= 3.5.0
 BuildRequires:  python%{python3_pkgversion}-setuptools_scm_git_archive
 
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
-Requires:       ansible >= 2.9
+# This should be
+# Requires:       (ansible >= 2.9 or ansible-core)
+# But our tooling currently fails with rich deps
+Requires:       /usr/bin/ansible
 Requires:       python%{python3_pkgversion}-enrich >= 1.2.6
 Requires:       python%{python3_pkgversion}-packaging
 Requires:       python%{python3_pkgversion}-pyyaml
@@ -51,6 +54,9 @@ rm -rf %{pypi_name}.egg-info
 %{python3_sitelib}/ansible_lint-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Tue Feb 22 2022 Evgeni Golov - 5.0.8-3
+- Require ansible OR ansible-core
+
 * Mon Sep 13 2021 Evgeni Golov - 5.0.8-2
 - Build against Python 3.8
 

--- a/packages/python-galaxy-importer/python-galaxy-importer.spec
+++ b/packages/python-galaxy-importer/python-galaxy-importer.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.4.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Galaxy content importer
 
 License:        Apache-2.0
@@ -26,7 +26,7 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 # We don't care if Ansible is Python 2 or 3 as we just call the CLI
-Requires:       ansible
+Requires:       /usr/bin/ansible
 Requires:       /usr/bin/ansible-test
 %if 0%{?rhel} == 8
 # We only have ansible-lint built on EL8
@@ -95,6 +95,9 @@ install -d -m 0755 %{buildroot}/%{_sysconfdir}/galaxy-importer/
 
 
 %changelog
+* Thu Feb 17 2022 Evgeni Golov - 0.4.1-2
+- Require /usr/bin/ansible
+
 * Tue Nov 09 2021 Odilon Sousa <osousa@redhat.com> - 0.4.1-1
 - Release python-galaxy-importer 0.4.1
 


### PR DESCRIPTION
this way we don't depend on the exact package name, which can vary