### PR TITLE
Move from Vault to Centos8-Stream

### DIFF
--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -17,31 +17,23 @@ module_platform_id=platform:el8
 [el8-baseos]
 name=BaseOS
 enabled=1
-#mirrorlist=http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=BaseOS
-baseurl=http://vault.centos.org/8.5.2111/BaseOS/$arch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=BaseOS
+#baseurl=http://vault.centos.org/8.5.2111/BaseOS/$arch/os/
 failovermethod=priority
 module_hotfixes=1
 
 [el8-appstream]
 name=AppStream
 enabled=1
-#mirrorlist=http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=AppStream
-baseurl=http://vault.centos.org/8.5.2111/AppStream/$arch/os/
-failovermethod=priority
-module_hotfixes=1
-
-[el8-configmanagement-ansible]
-name=Ansible configmanagement
-enabled=1
-#mirrorlist=http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=configmanagement-ansible-29
-baseurl=http://vault.centos.org/8.5.2111/configmanagement/$arch/ansible-29/
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=AppStream
+#baseurl=http://vault.centos.org/8.5.2111/AppStream/$arch/os/
 failovermethod=priority
 module_hotfixes=1
 
 [el8-extras]
 name=extras
-#mirrorlist=http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=extras
-baseurl=http://vault.centos.org/8.5.2111/extras/$arch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=extras
+#baseurl=http://vault.centos.org/8.5.2111/extras/$arch/os/
 module_hotfixes=1
 
 [el8-epel]
@@ -52,15 +44,15 @@ module_hotfixes=1
 
 [el8-devel]
 name=devel
-#mirrorlist=http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=devel
-baseurl=http://vault.centos.org/8.5.2111.4.2105/Devel/x86_64/os/
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=devel
+#baseurl=http://vault.centos.org/8.5.2111.4.2105/Devel/x86_64/os/
 failovermethod=priority
 module_hotfixes=1
 
 [el8-powertools]
 name=powertools
-#mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=PowerTools&infra=$infra
-baseurl=http://vault.centos.org/8.5.2111/PowerTools/$arch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=PowerTools&infra=$infra
+#baseurl=http://vault.centos.org/8.5.2111/PowerTools/$arch/os/
 failovermethod=priority
 module_hotfixes=1
 


### PR DESCRIPTION
I'm opening this PR to move from Vault to Centos8Stream for repoclosure, the past week we had some timeouts with vault, it's not reliable and will only get older with time. 

el8-configmanagement-ansible was removed because the package `centos-release-ansible-29` is now provided by Extras. 