### PR TITLE
[3.18] Build python-pytz against Python 3.9 on el8/9

### DIFF
--- a/packages/python-pytz/python-pytz.spec
+++ b/packages/python-pytz/python-pytz.spec
@@ -1,12 +1,9 @@
-%{?scl:%scl_package python-%{pypi_name}}
-%{!?scl:%global pkg_name %{name}}
-
 # Created by pyp2rpm-3.3.3
 %global pypi_name pytz
 
-Name:           %{?scl_prefix}python-%{pypi_name}
+Name:           python-%{pypi_name}
 Version:        2021.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        World timezone definitions, modern and historical
 
 License:        MIT
@@ -14,47 +11,38 @@ URL:            http://pythonhosted.org/pytz
 Source0:        https://files.pythonhosted.org/packages/source/p/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 
-BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-devel
-BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-setuptools
 
 
 %description
 %{summary}
 
 
-%package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
+%package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
 
-%description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
+%description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
 
 
 %prep
-%{?scl:scl enable %{scl} - << \EOF}
-set -ex
 %autosetup -n %{pypi_name}-%{version}
 # Remove bundled egg-info
 rm -rf %{pypi_name}.egg-info
-%{?scl:EOF}
 
 
 %build
-%{?scl:scl enable %{scl} - << \EOF}
-set -ex
 %py3_build
-%{?scl:EOF}
 
 
 %install
-%{?scl:scl enable %{scl} - << \EOF}
-set -ex
 %py3_install
-%{?scl:EOF}
 
 
-%files -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
+%files -n python%{python3_pkgversion}-%{pypi_name}
 %license LICENSE.txt
 %doc README.rst
 %{python3_sitelib}/%{pypi_name}
@@ -62,6 +50,10 @@ set -ex
 
 
 %changelog
+* Thu Apr 07 2022 Dimitri Savineau <dsavinea@redhat.com> - 2021.3-2
+- Build against Python 3.9
+- Drop SCL configuration
+
 * Wed Nov 03 2021 Odilon Sousa 2021.3-1
 - Update to 2021.3
 


### PR DESCRIPTION
el7 isn't a target anymore so we don't need the SCL configuration.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>