### PR TITLE
use el9-crb repo, the powertools name is only for el8

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -23,7 +23,7 @@ repoclosures:
         el9:
           - el9-baseos
           - el9-appstream
-          - el9-powertools
+          - el9-crb
     pulpcore-repoclosure-el8:
       repoclosure_target_repos:
         el8:
@@ -54,7 +54,7 @@ pulpcore_packages:
       el9:
         - el9-baseos
         - el9-appstream
-        - el9-powertools
+        - el9-crb
       el8:
         - el8-baseos
         - el8-appstream


### PR DESCRIPTION
this was set correctly in repoclosure/yum.conf, but not in the manifest