### PR TITLE
python-pulp-container: Bump to 2.10.3

### DIFF
--- a/packages/python-pulp-container/pulp-container-2.10.3.tar.gz
+++ b/packages/python-pulp-container/pulp-container-2.10.3.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/85/14/SHA256E-s105142--761a0908b5dc66c0afeee957359a99453aff8f612a1c9b86cc9fdf28e48c6d92.tar.gz/SHA256E-s105142--761a0908b5dc66c0afeee957359a99453aff8f612a1c9b86cc9fdf28e48c6d92.tar.gz

--- a/packages/python-pulp-container/pulp-container-2.11.0.tar.gz
+++ b/packages/python-pulp-container/pulp-container-2.11.0.tar.gz
@@ -1,1 +1,0 @@
-../../.git/annex/objects/80/pk/SHA256E-s124185--c5d35ad18a530ab3e9be3774e065b431eaebe32e57993c8b34dc7788409dbc99.tar.gz/SHA256E-s124185--c5d35ad18a530ab3e9be3774e065b431eaebe32e57993c8b34dc7788409dbc99.tar.gz

--- a/packages/python-pulp-container/python-pulp-container.spec
+++ b/packages/python-pulp-container/python-pulp-container.spec
@@ -5,7 +5,7 @@
 %global pypi_name pulp-container
 
 Name:           %{?scl_prefix}python-%{pypi_name}
-Version:        2.11.0
+Version:        2.10.3
 Release:        1%{?dist}
 Summary:        Container plugin for the Pulp Project
 
@@ -73,8 +73,8 @@ set -ex
 
 
 %changelog
-* Wed Apr 27 2022 Odilon Sousa <osousa@redhat.com> - 2.11.0-1
-- Release python-pulp-container 2.11.0
+* Mon May 02 2022 Yanis Guenane <yguenane@redhat.com> - 2.10.3-1
+- Release python-pulp-container 2.10.3
 
 * Fri Apr 22 2022 Yanis Guenane <yguenane@redhat.com> - 2.10.0-2
 - Build against python 3.9


### PR DESCRIPTION
As per galaxy_ng new BuildRequire https://github.com/theforeman/pulpcore-packaging/blob/rpm/3.18/packages/python-galaxy-ng/python-galaxy-ng.spec#L37-L38