### PR TITLE
Exclude files in bin for a better upgrade from python38 to python39 

### DIFF
--- a/packages/python-bindep/python-bindep.spec
+++ b/packages/python-bindep/python-bindep.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.10.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Binary dependency utility
 
 License:        Apache License, Version 2.0
@@ -17,12 +17,6 @@ BuildArch:      noarch
 BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-devel
 BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-pbr >= 2.0.0
 BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
-
-Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
-%if 0%{?rhel} == 8
-Obsoletes:      python38-%{pypi_name} < %{version}-%{release}
-%endif
-
 
 %description
 %{summary}
@@ -67,12 +61,16 @@ set -ex
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %license LICENSE
 %doc README.rst doc/source/readme.rst
-%{_bindir}/bindep
+%exclude %{_bindir}/bindep
 %{python3_sitelib}/%{pypi_name}
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Mon Jun 13 2022 Odilon Sousa <osousa@redhat.com> - 2.10.2-4
+- Exclude files in bin for a better upgrade from python38 to python39 and
+  removes Obsolete
+
 * Mon May 23 2022 Odilon Sousa <osousa@redhat.com> - 2.10.2-3
 - Obsolete the old Python 3.8 package for smooth upgrade
 

--- a/packages/python-cchardet/python-cchardet.spec
+++ b/packages/python-cchardet/python-cchardet.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.1.7
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        cChardet is high speed universal character encoding detector
 
 License:        Mozilla Public License
@@ -15,11 +15,6 @@ Source0:        https://files.pythonhosted.org/packages/source/c/%{pypi_name}/%{
 
 BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-devel
 BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
-
-Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
-%if 0%{?rhel} == 8
-Obsoletes:      python38-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description
 %{summary}
@@ -59,12 +54,15 @@ set -ex
 
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %doc README.rst src/ext/uchardet/README.md src/ext/uchardet/doc/README.maintainer
-%{_bindir}/cchardetect
+%exclude %{_bindir}/cchardetect
 %{python3_sitearch}/%{pypi_name}
 %{python3_sitearch}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Mon Jun 13 2022 Odilon Sousa <osousa@redhat.com> - 2.1.7-4
+- Exclude files in bin for a better upgrade from python38 to python39 and removes Obsolete
+
 * Mon May 23 2022 Odilon Sousa <osousa@redhat.com> - 2.1.7-3
 - Obsolete the old Python 3.8 package for smooth upgrade
 

--- a/packages/python-charset-normalizer/python-charset-normalizer.spec
+++ b/packages/python-charset-normalizer/python-charset-normalizer.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.0.11
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet
 
 License:        MIT
@@ -26,12 +26,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
-
-
-Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
-%if 0%{?rhel} == 8
-Obsoletes:      python38-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -63,12 +57,15 @@ set -ex
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %license LICENSE
 %doc README.md
-%{_bindir}/normalizer
+%exclude %{_bindir}/normalizer
 %{python3_sitelib}/charset_normalizer
 %{python3_sitelib}/charset_normalizer-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Mon Jun 13 2022 Odilon Sousa <osousa@redhat.com> - 2.0.11-4
+- Exclude files in bin for a better upgrade from python38 to python39 and removes Obsolete
+
 * Mon May 23 2022 Odilon Sousa <osousa@redhat.com> - 2.0.11-3
 - Obsolete the old Python 3.8 package for smooth upgrade
 

--- a/packages/python-pbr/python-pbr.spec
+++ b/packages/python-pbr/python-pbr.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        5.8.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Python Build Reasonableness
 
 License:        None
@@ -27,11 +27,6 @@ BuildArch:      noarch
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
-
-Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
-%if 0%{?rhel} == 8
-Obsoletes:      python38-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -63,12 +58,16 @@ set -ex
 %files -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %license LICENSE pbr/tests/testpackage/LICENSE.txt
 %doc README.rst pbr/tests/testpackage/README.txt
-%{_bindir}/pbr
+%exclude %{_bindir}/pbr
 %{python3_sitelib}/%{pypi_name}
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 
 %changelog
+* Mon Jun 13 2022 Odilon Sousa <osousa@redhat.com> - 5.8.0-4
+- Exclude files in bin for a better upgrade from python38 to python39 and
+  removes Obsolete
+
 * Mon May 23 2022 Odilon Sousa <osousa@redhat.com> - 5.8.0-3
 - Obsolete the old Python 3.8 package for smooth upgrade
 


### PR DESCRIPTION
While performing a `yum update` with Pulpcore 3.17 installed we get the following error. 

```
Error: 
 Problem 1: package python39-charset-normalizer-2.0.11-3.el8.noarch obsoletes python38-charset-normalizer < 2.0.11-3.el8 provided by python38-charset-normalizer-2.0.11-1.el8.noarch
  - package python38-aiohttp-3.8.1-2.el8.x86_64 requires python38-charset-normalizer >= 2.0, but none of the providers can be installed
  - package python38-aiohttp-3.8.1-2.el8.x86_64 requires python38-charset-normalizer < 3.0, but none of the providers can be installed
  - cannot install the best update candidate for package python38-charset-normalizer-2.0.11-1.el8.noarch
  - problem with installed package python38-aiohttp-3.8.1-2.el8.x86_64
 Problem 2: package python39-pbr-5.8.0-3.el8.noarch obsoletes python38-pbr < 5.8.0-3.el8 provided by python38-pbr-5.8.0-1.el8.noarch
  - package python38-bindep-2.10.2-1.el8.noarch requires python38-pbr >= 2.0.0, but none of the providers can be installed
  - cannot install the best update candidate for package python38-pbr-5.8.0-1.el8.noarch
  - problem with installed package python38-bindep-2.10.2-1.el8.noarch
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```


Looking deeper into the dnf install error, I caught this

Error: Transaction test error:
  file /usr/bin/normalizer from install of python39-charset-normalizer-2.0.11-2.el8.noarch conflicts with file from package python38-charset-normalizer-2.0.11-1.el8.noarch
  file /usr/bin/cchardetect from install of python39-cchardet-2.1.7-3.el8.x86_64 conflicts with file from package python38-cchardet-2.1.7-1.el8.x86_64

The '/usr/bin/<package>' is not necessary on Pulpcore.

I've used the RPMs generated by this scratch run, and they installed and replaced the old python38 packages.

```
dnf install python39-aiohttp http://koji.katello.org/kojifiles/work/tasks/8987/518987/python39-charset-normalizer-2.0.11-4.el8.noarch.rpm
Last metadata expiration check: 0:07:05 ago on Mon 13 Jun 2022 07:57:24 PM UTC.
python39-charset-normalizer-2.0.11-4.el8.noarch.rpm                                                             83 kB/s |  72 kB     00:00    
Dependencies resolved.
===============================================================================================================================================
 Package                                       Architecture             Version                           Repository                      Size
===============================================================================================================================================
Installing:
 python39-aiohttp                              x86_64                   3.8.1-3.el8                       pulpcore                       596 k
 python39-charset-normalizer                   noarch                   2.0.11-4.el8                      @commandline                    72 k
Installing dependencies:
 python39-aiodns                               noarch                   3.0.0-3.el8                       pulpcore                        16 k
 python39-aiosignal                            noarch                   1.2.0-2.el8                       pulpcore                        17 k
 python39-async-timeout                        noarch                   4.0.2-2.el8                       pulpcore                        16 k
 python39-attrs                                noarch                   21.4.0-2.el8                      pulpcore                        96 k
 python39-brotli                               x86_64                   1.0.9-2.el8                       pulpcore                       312 k
 python39-cffi                                 x86_64                   1.15.0-2.el8                      pulpcore                       243 k
 python39-frozenlist                           x86_64                   1.3.0-2.el8                       pulpcore                        45 k
 python39-idna                                 noarch                   3.3-2.el8                         pulpcore                        84 k
 python39-idna-ssl                             noarch                   1.1.0-5.el8                       pulpcore                        12 k
 python39-multidict                            x86_64                   6.0.2-2.el8                       pulpcore                        49 k
 python39-pycares                              x86_64                   4.1.2-2.el8                       pulpcore                        95 k
 python39-pycparser                            noarch                   2.21-2.el8                        pulpcore                       201 k
 python39-typing-extensions                    noarch                   3.10.0.2-2.el8                    pulpcore                        52 k
 python39-yarl                                 x86_64                   1.7.2-2.el8                       pulpcore                       128 k

Transaction Summary
===============================================================================================================================================
Install  16 Packages

Total size: 2.0 M
Installed size: 9.3 M
Is this ok [y/N]: y
Downloading Packages:
[SKIPPED] python39-aiodns-3.0.0-3.el8.noarch.rpm: Already downloaded                                                                          
[SKIPPED] python39-aiohttp-3.8.1-3.el8.x86_64.rpm: Already downloaded                                                                         
[SKIPPED] python39-aiosignal-1.2.0-2.el8.noarch.rpm: Already downloaded                                                                       
[SKIPPED] python39-async-timeout-4.0.2-2.el8.noarch.rpm: Already downloaded                                                                   
[SKIPPED] python39-attrs-21.4.0-2.el8.noarch.rpm: Already downloaded                                                                          
[SKIPPED] python39-brotli-1.0.9-2.el8.x86_64.rpm: Already downloaded                                                                          
[SKIPPED] python39-cffi-1.15.0-2.el8.x86_64.rpm: Already downloaded                                                                           
[SKIPPED] python39-frozenlist-1.3.0-2.el8.x86_64.rpm: Already downloaded                                                                      
[SKIPPED] python39-idna-3.3-2.el8.noarch.rpm: Already downloaded                                                                              
[SKIPPED] python39-idna-ssl-1.1.0-5.el8.noarch.rpm: Already downloaded                                                                        
[SKIPPED] python39-multidict-6.0.2-2.el8.x86_64.rpm: Already downloaded                                                                       
[SKIPPED] python39-pycares-4.1.2-2.el8.x86_64.rpm: Already downloaded                                                                         
[SKIPPED] python39-pycparser-2.21-2.el8.noarch.rpm: Already downloaded                                                                        
[SKIPPED] python39-typing-extensions-3.10.0.2-2.el8.noarch.rpm: Already downloaded                                                            
[SKIPPED] python39-yarl-1.7.2-2.el8.x86_64.rpm: Already downloaded                                                                            
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                       1/1 
  Installing       : python39-typing-extensions-3.10.0.2-2.el8.noarch                                                                     1/16 
  Installing       : python39-idna-3.3-2.el8.noarch                                                                                       2/16 
  Installing       : python39-multidict-6.0.2-2.el8.x86_64                                                                                3/16 
  Installing       : python39-frozenlist-1.3.0-2.el8.x86_64                                                                               4/16 
  Installing       : python39-aiosignal-1.2.0-2.el8.noarch                                                                                5/16 
  Installing       : python39-yarl-1.7.2-2.el8.x86_64                                                                                     6/16 
  Installing       : python39-idna-ssl-1.1.0-5.el8.noarch                                                                                 7/16 
  Installing       : python39-async-timeout-4.0.2-2.el8.noarch                                                                            8/16 
  Installing       : python39-charset-normalizer-2.0.11-4.el8.noarch                                                                      9/16 
  Installing       : python39-pycparser-2.21-2.el8.noarch                                                                                10/16 
  Installing       : python39-cffi-1.15.0-2.el8.x86_64                                                                                   11/16 
  Installing       : python39-pycares-4.1.2-2.el8.x86_64                                                                                 12/16 
  Installing       : python39-aiodns-3.0.0-3.el8.noarch                                                                                  13/16 
  Installing       : python39-brotli-1.0.9-2.el8.x86_64                                                                                  14/16 
  Installing       : python39-attrs-21.4.0-2.el8.noarch                                                                                  15/16 
  Installing       : python39-aiohttp-3.8.1-3.el8.x86_64                                                                                 16/16 
  Running scriptlet: python39-aiohttp-3.8.1-3.el8.x86_64                                                                                 16/16 
  Verifying        : python39-aiodns-3.0.0-3.el8.noarch                                                                                   1/16 
  Verifying        : python39-aiohttp-3.8.1-3.el8.x86_64                                                                                  2/16 
  Verifying        : python39-aiosignal-1.2.0-2.el8.noarch                                                                                3/16 
  Verifying        : python39-async-timeout-4.0.2-2.el8.noarch                                                                            4/16 
  Verifying        : python39-attrs-21.4.0-2.el8.noarch                                                                                   5/16 
  Verifying        : python39-brotli-1.0.9-2.el8.x86_64                                                                                   6/16 
  Verifying        : python39-cffi-1.15.0-2.el8.x86_64                                                                                    7/16 
  Verifying        : python39-frozenlist-1.3.0-2.el8.x86_64                                                                               8/16 
  Verifying        : python39-idna-3.3-2.el8.noarch                                                                                       9/16 
  Verifying        : python39-idna-ssl-1.1.0-5.el8.noarch                                                                                10/16 
  Verifying        : python39-multidict-6.0.2-2.el8.x86_64                                                                               11/16 
  Verifying        : python39-pycares-4.1.2-2.el8.x86_64                                                                                 12/16 
  Verifying        : python39-pycparser-2.21-2.el8.noarch                                                                                13/16 
  Verifying        : python39-typing-extensions-3.10.0.2-2.el8.noarch                                                                    14/16 
  Verifying        : python39-yarl-1.7.2-2.el8.x86_64                                                                                    15/16 
  Verifying        : python39-charset-normalizer-2.0.11-4.el8.noarch                                                                     16/16 

Installed:
  python39-aiodns-3.0.0-3.el8.noarch         python39-aiohttp-3.8.1-3.el8.x86_64              python39-aiosignal-1.2.0-2.el8.noarch            
  python39-async-timeout-4.0.2-2.el8.noarch  python39-attrs-21.4.0-2.el8.noarch               python39-brotli-1.0.9-2.el8.x86_64               
  python39-cffi-1.15.0-2.el8.x86_64          python39-charset-normalizer-2.0.11-4.el8.noarch  python39-frozenlist-1.3.0-2.el8.x86_64           
  python39-idna-3.3-2.el8.noarch             python39-idna-ssl-1.1.0-5.el8.noarch             python39-multidict-6.0.2-2.el8.x86_64            
  python39-pycares-4.1.2-2.el8.x86_64        python39-pycparser-2.21-2.el8.noarch             python39-typing-extensions-3.10.0.2-2.el8.noarch 
  python39-yarl-1.7.2-2.el8.x86_64
```