### PR TITLE
Force setuptools_scm usage for older setuptools for python-importlib-resources

### DIFF
--- a/packages/python-importlib-resources/importlib_resources-5.0.0.tar.gz
+++ b/packages/python-importlib-resources/importlib_resources-5.0.0.tar.gz
@@ -1,1 +1,0 @@
-../../.git/annex/objects/pp/8Z/SHA256E-s30603--4743f090ed8946e713745ec0e660249ef9fb0b9843eacc5b5ff931d2fd5aa67f.tar.gz/SHA256E-s30603--4743f090ed8946e713745ec0e660249ef9fb0b9843eacc5b5ff931d2fd5aa67f.tar.gz

--- a/packages/python-importlib-resources/importlib_resources-5.4.0.tar.gz
+++ b/packages/python-importlib-resources/importlib_resources-5.4.0.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/9Z/4p/SHA256E-s30554--d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b.tar.gz/SHA256E-s30554--d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b.tar.gz

--- a/packages/python-importlib-resources/python-importlib-resources.spec
+++ b/packages/python-importlib-resources/python-importlib-resources.spec
@@ -5,7 +5,7 @@
 %global pypi_name importlib-resources
 
 Name:           %{?scl_prefix}python-%{pypi_name}
-Version:        5.0.0
+Version:        5.4.0
 Release:        3%{?dist}
 Summary:        Read resources from Python packages
 
@@ -67,6 +67,9 @@ set -ex
 
 
 %changelog
+* Mon Aug 08 2022 Odilon Sousa <osousa@redhat.com> - 5.4.0-3
+- Force setuptools_scm usage for older setuptools for python-importlib-resources
+
 * Fri Aug 05 2022 Odilon Sousa <osousa@redhat.com> - 5.0.0-3
 - Force setuptools_scm usage for older setuptools on python-importlib-resources
 


### PR DESCRIPTION
I was not able to do a clean cherry-pick, doing to we having too many branches and minor versions of the same package in different python version

:sob: 