### PR TITLE
Bump python-debian to 0.1.44 (for rpm/3.16)

### DIFF
--- a/packages/python-debian/python-debian-0.1.42.tar.gz
+++ b/packages/python-debian/python-debian-0.1.42.tar.gz
@@ -1,1 +1,0 @@
-../../.git/annex/objects/m6/Xv/SHA256E-s108672--a794f4c4ee2318ae7260c2e32dac252b833bdaf6686efc2a1afbc6ecf3f0931f.tar.gz/SHA256E-s108672--a794f4c4ee2318ae7260c2e32dac252b833bdaf6686efc2a1afbc6ecf3f0931f.tar.gz

--- a/packages/python-debian/python-debian-0.1.44.tar.gz
+++ b/packages/python-debian/python-debian-0.1.44.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/FJ/jw/SHA256E-s111386--65592fe3b64f6c6c93d94e2d2599db5e0c22831d3bcff07cb7b96d3840b1333e.tar.gz/SHA256E-s111386--65592fe3b64f6c6c93d94e2d2599db5e0c22831d3bcff07cb7b96d3840b1333e.tar.gz

--- a/packages/python-debian/python-debian.spec
+++ b/packages/python-debian/python-debian.spec
@@ -6,8 +6,8 @@
 %global srcname debian
 
 Name:           %{?scl_prefix}python-%{srcname}
-Version:        0.1.42
-Release:        1%{?dist}
+Version:        0.1.44
+Release:        2%{?dist}
 Summary:        Debian package related modules
 
 License:        GPL-2+
@@ -28,6 +28,7 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-chardet
+Requires:       zstd
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -67,6 +68,11 @@ set -ex
 
 
 %changelog
+* Mon Aug 22 2022 Quirin Pamp <pamp@atix.de> - 0.1.44-2
+- Update to 0.1.44
+- Add zstd dependency to support zstd compression for Ubuntu.
+- Use revision 2 to ensure build against python 3.8.
+
 * Wed Nov 03 2021 Odilon Sousa 0.1.42-1
 - Update to 0.1.42
 


### PR DESCRIPTION
Was already done for `rpm/3.18`: https://github.com/theforeman/pulpcore-packaging/pull/548