### PR TITLE
Bump python-debian release version

### DIFF
--- a/packages/python-debian/python-debian.spec
+++ b/packages/python-debian/python-debian.spec
@@ -7,7 +7,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        0.1.44
-Release:        1%{?dist}
+Release:        3%{?dist}
 Summary:        Debian package related modules
 
 License:        GPL-2+
@@ -67,6 +67,9 @@ set -ex
 
 
 %changelog
+* Wed Aug 24 2022 Quirin Pamp <pamp@atix.de> - 0.1.44-3
+- Bump release to 3 to ensure a smooth upgrade from the 3.16 repo.
+
 * Thu Aug 18 2022 Quirin Pamp <pamp@atix.de> - 0.1.44-1
 - Update to 0.1.44
 - Add zstd dependency to support zstd compression for Ubuntu.


### PR DESCRIPTION
This is intended to ensure a smooth upgrade from the version we are
building for the rpm/3.16 branch.

See also: https://github.com/theforeman/pulpcore-packaging/pull/549#discussion_r951423284