### PR TITLE
Use %{pypi_name} for %autosetup

### DIFF
--- a/packages/python-pulp-manifest/python-pulp-manifest.spec
+++ b/packages/python-pulp-manifest/python-pulp-manifest.spec
@@ -33,7 +33,7 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %prep
 %{?scl:scl enable %{scl} - << \EOF}
 set -ex
-%autosetup -n pulp-manifest-%{version}
+%autosetup -n %{pypi_name}-%{version}
 %{?scl:EOF}
 
 


### PR DESCRIPTION
We tried to package pulp-manifest using the spec file and the [pulp-manifest source code from github](https://github.com/pulp/pulp-manifest.git).

First we created a source distribution by `python3 setup.py sdist`. This creates a source distribution archive `pulp_manifest.tar.gz` which seems correct according to the `name` provided in `setup.py` and the `pypi_name` in the spec file.
Unfortunately at the `autosetup` step `pulp-manifest` is used hard coded. Therefore the build fails as the source distribution is written with an underscore and is therefore extracted to `pulp_manifest` as specified by the `pypi_name`.

IMO `pypi_name` should be used at the `autosetup` step.