### PR TITLE
Update Django to fix cve-2022-41323

### DIFF
--- a/packages/python-django/Django-3.2.14.tar.gz
+++ b/packages/python-django/Django-3.2.14.tar.gz
@@ -1,1 +1,0 @@
-../../.git/annex/objects/Vf/9w/SHA256E-s9814965--677182ba8b5b285a4e072f3ac17ceee6aff1b5ce77fd173cc5b6a2d3dc022fcf.tar.gz/SHA256E-s9814965--677182ba8b5b285a4e072f3ac17ceee6aff1b5ce77fd173cc5b6a2d3dc022fcf.tar.gz

--- a/packages/python-django/Django-3.2.16.tar.gz
+++ b/packages/python-django/Django-3.2.16.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/gJ/qF/SHA256E-s9847052--3adc285124244724a394fa9b9839cc8cd116faf7d159554c43ecdaa8cdf0b94d.tar.gz/SHA256E-s9847052--3adc285124244724a394fa9b9839cc8cd116faf7d159554c43ecdaa8cdf0b94d.tar.gz

--- a/packages/python-django/python-django.spec
+++ b/packages/python-django/python-django.spec
@@ -6,8 +6,8 @@
 %global srcname django
 
 Name:           %{?scl_prefix}python-%{srcname}
-Version:        3.2.14
-Release:        2%{?dist}
+Version:        3.2.16
+Release:        1%{?dist}
 Summary:        A high-level Python Web framework that encourages rapid development and clean, pragmatic design
 
 License:        BSD-3-Clause
@@ -84,6 +84,9 @@ set -ex
 
 
 %changelog
+* Tue Jan 24 2023 Odilon Sousa <osousa@redhat.com> - 3.2.16-1
+- Release python-django 3.2.16
+
 * Thu Sep 22 2022 Odilon Sousa <osousa@redhat.com> - 3.2.14-2
 - Bump version for a python39 rebuild
 


### PR DESCRIPTION
(cherry picked from commit 236dd8e3af5f1f440b6575f3848d50530dfeea0c)