### PR TITLE
Update python-future to 0.18.3

### DIFF
--- a/packages/python-future/future-0.18.2.tar.gz
+++ b/packages/python-future/future-0.18.2.tar.gz
@@ -1,1 +1,0 @@
-../../.git/annex/objects/MZ/5j/SHA256E-s829220--b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d.tar.gz/SHA256E-s829220--b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d.tar.gz

--- a/packages/python-future/future-0.18.3.tar.gz
+++ b/packages/python-future/future-0.18.3.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/81/fj/SHA256E-s840896--34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307.tar.gz/SHA256E-s840896--34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307.tar.gz

--- a/packages/python-future/python-future.spec
+++ b/packages/python-future/python-future.spec
@@ -5,8 +5,8 @@
 %global pypi_name future
 
 Name:           %{?scl_prefix}python-%{pypi_name}
-Version:        0.18.2
-Release:        5%{?dist}
+Version:        0.18.3
+Release:        1%{?dist}
 Summary:        Clean single-source support for Python 3 and 2
 
 License:        MIT
@@ -68,6 +68,9 @@ set -ex
 
 
 %changelog
+* Thu Apr 13 2023 Odilon Sousa <osousa@redhat.com> - 0.18.3-1
+- Release python-future 0.18.3
+
 * Fri Apr 22 2022 Yanis Guenane <yguenane@redhat.com> - 0.18.2-5
 - Build against python 3.9
 


### PR DESCRIPTION
Fixes CVE-2022-40899