### PR TITLE
Update requirements for repoclosure on 3.28 release

### DIFF
--- a/comps/comps-pulpcore-el8.xml
+++ b/comps/comps-pulpcore-el8.xml
@@ -184,6 +184,7 @@
       <packagereq type="default">python39-opentelemetry_sdk</packagereq>
       <packagereq type="default">python39-opentelemetry_semantic_conventions</packagereq>
       <packagereq type="default">python39-opentelemetry_util_http</packagereq>
+      <packagereq type="default">python39-opentelemetry_proto</packagereq>
       <packagereq type="default">python39-packaging</packagereq>
       <packagereq type="default">python39-parsley</packagereq>
       <packagereq type="default">python39-pathspec</packagereq>

--- a/comps/comps-pulpcore-el8.xml
+++ b/comps/comps-pulpcore-el8.xml
@@ -123,7 +123,6 @@
       <packagereq type="default">python39-frozenlist</packagereq>
       <packagereq type="default">python39-future</packagereq>
       <packagereq type="default">python39-galaxy-importer</packagereq>
-      <packagereq type="default">python39-galaxy-ng</packagereq>
       <packagereq type="default">python39-gitdb</packagereq>
       <packagereq type="default">python39-gitpython</packagereq>
       <packagereq type="default">python39-gnupg</packagereq>

--- a/comps/comps-pulpcore-el8.xml
+++ b/comps/comps-pulpcore-el8.xml
@@ -88,7 +88,6 @@
       <packagereq type="default">python39-django-automated-logging</packagereq>
       <packagereq type="default">python39-django-auth-ldap</packagereq>      
       <packagereq type="default">python39-django-cleanup</packagereq>
-      <packagereq type="default">python39-django-currentuser</packagereq>
       <packagereq type="default">python39-django-filter</packagereq>
       <packagereq type="default">python39-django-guardian</packagereq>
       <packagereq type="default">python39-django-guid</packagereq>

--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -123,7 +123,6 @@
       <packagereq type="default">python3-frozenlist</packagereq>
       <packagereq type="default">python3-future</packagereq>
       <packagereq type="default">python3-galaxy-importer</packagereq>
-      <packagereq type="default">python3-galaxy-ng</packagereq>
       <packagereq type="default">python3-gitdb</packagereq>
       <packagereq type="default">python3-gitpython</packagereq>
       <packagereq type="default">python3-gnupg</packagereq>

--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -184,6 +184,7 @@
       <packagereq type="default">python3-opentelemetry_sdk</packagereq>
       <packagereq type="default">python3-opentelemetry_semantic_conventions</packagereq>
       <packagereq type="default">python3-opentelemetry_util_http</packagereq>
+      <packagereq type="default">python3-opentelemetry_proto</packagereq>
       <packagereq type="default">python3-packaging</packagereq>
       <packagereq type="default">python3-parsley</packagereq>
       <packagereq type="default">python3-pathspec</packagereq>

--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -88,7 +88,6 @@
       <packagereq type="default">python3-django-automated-logging</packagereq>
       <packagereq type="default">python3-django-auth-ldap</packagereq>
       <packagereq type="default">python3-django-cleanup</packagereq>
-      <packagereq type="default">python3-django-currentuser</packagereq>
       <packagereq type="default">python3-django-filter</packagereq>
       <packagereq type="default">python3-django-guardian</packagereq>
       <packagereq type="default">python3-django-guid</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -126,7 +126,6 @@ pulpcore_packages:
     python-django-automated-logging: {}
     python-django-auth-ldap: {}
     python-django-cleanup: {}
-    python-django-currentuser: {}
     python-django-filter: {}
     python-django-guardian: {}
     python-django-guid: {}

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -166,7 +166,6 @@ pulpcore_packages:
     python-flit_scm: {}
     python-future: {}
     python-galaxy-importer: {}
-    python-galaxy-ng: {}
     python-gnupg: {}
     python-googleapis-common-protos: {}
     python-grpcio: {}

--- a/packages/python-django-guid/python-django-guid.spec
+++ b/packages/python-django-guid/python-django-guid.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.3.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Middleware that enables single request-response cycle tracing by injecting a unique ID into project logs
 
 License:        BSD
@@ -25,7 +25,7 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
-Requires:       %{?scl_prefix}python%{python3_pkgversion}-django < 4.0.0
+Requires:       %{?scl_prefix}python%{python3_pkgversion}-django < 5.0.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-django >= 3.1.1
 %if 0%{?!scl:1}
 Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
@@ -67,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 3.3.0-2
+- Update django requirement
+
 * Tue Sep 20 2022 Odilon Sousa 3.3.0-1
 - Update to 3.3.0
 

--- a/packages/python-opentelemetry_distro/python-opentelemetry_distro.spec
+++ b/packages/python-opentelemetry_distro/python-opentelemetry_distro.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.40b0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OpenTelemetry Python Distro
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -24,11 +24,11 @@ BuildRequires:  python%{python3_pkgversion}-tomli
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
-Requires:       python%{python3_pkgversion}-opentelemetry-api >= 1.12
-Requires:       python%{python3_pkgversion}-opentelemetry-api < 2
-Requires:       python%{python3_pkgversion}-opentelemetry-instrumentation == 0.41b0.dev
-Requires:       python%{python3_pkgversion}-opentelemetry-sdk >= 1.13
-Requires:       python%{python3_pkgversion}-opentelemetry-sdk < 2
+Requires:       python%{python3_pkgversion}-opentelemetry_api >= 1.12
+Requires:       python%{python3_pkgversion}-opentelemetry_api < 2
+Requires:       python%{python3_pkgversion}-opentelemetry_instrumentation == 0.41b0.dev
+Requires:       python%{python3_pkgversion}-opentelemetry_sdk >= 1.13
+Requires:       python%{python3_pkgversion}-opentelemetry_sdk < 2
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -53,5 +53,8 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 0.40b0-2
+- Update opentelemetry dependency names
+
 * Wed Jul 26 2023 Odilon Sousa - 0.40b0-1
 - Initial package.

--- a/packages/python-opentelemetry_exporter_otlp/python-opentelemetry_exporter_otlp.spec
+++ b/packages/python-opentelemetry_exporter_otlp/python-opentelemetry_exporter_otlp.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.19.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OpenTelemetry Collector Exporters
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -24,8 +24,8 @@ BuildRequires:  python%{python3_pkgversion}-tomli
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
-Requires:       python%{python3_pkgversion}-opentelemetry-exporter-otlp-proto-grpc >= 1.19.0
-Requires:       python%{python3_pkgversion}-opentelemetry-exporter-otlp-proto-http >= 1.19.0
+Requires:       python%{python3_pkgversion}-opentelemetry_exporter_otlp_proto_grpc >= 1.19.0
+Requires:       python%{python3_pkgversion}-opentelemetry_exporter_otlp_proto_http >= 1.19.0
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -50,5 +50,8 @@ set -ex
 %{python3_sitelib}/opentelemetry/exporter/otlp
 
 %changelog
+* Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 1.19.0-2
+- Update opentelemetry dependency names
+
 * Wed Jul 26 2023 Odilon Sousa - 1.19.0-1
 - Initial package.

--- a/packages/python-opentelemetry_exporter_otlp_proto_grpc/python-opentelemetry_exporter_otlp_proto_grpc.spec
+++ b/packages/python-opentelemetry_exporter_otlp_proto_grpc/python-opentelemetry_exporter_otlp_proto_grpc.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.19.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        OpenTelemetry Collector Protobuf over gRPC Exporter
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -31,12 +31,12 @@ Requires:       python%{python3_pkgversion}-googleapis-common-protos >= 1.52
 Requires:       python%{python3_pkgversion}-googleapis-common-protos < 2
 Requires:       python%{python3_pkgversion}-grpcio >= 1.0.0
 Requires:       python%{python3_pkgversion}-grpcio < 2.0.0
-Requires:       python%{python3_pkgversion}-opentelemetry-api >= 1.15.0
-Requires:       python%{python3_pkgversion}-opentelemetry-api < 2.0.0
-Requires:       python%{python3_pkgversion}-opentelemetry-proto = 1.19.0
-Requires:       python%{python3_pkgversion}-opentelemetry-sdk  >= 1.19.0
-Requires:       python%{python3_pkgversion}-opentelemetry-sdk  < 2.0.0
-Requires:       python%{python3_pkgversion}-opentelemetry-exporter-otlp-proto-common = 1.19.0
+Requires:       python%{python3_pkgversion}-opentelemetry_api >= 1.15.0
+Requires:       python%{python3_pkgversion}-opentelemetry_api < 2.0.0
+Requires:       python%{python3_pkgversion}-opentelemetry_proto = 1.19.0
+Requires:       python%{python3_pkgversion}-opentelemetry_sdk  >= 1.19.0
+Requires:       python%{python3_pkgversion}-opentelemetry_sdk  < 2.0.0
+Requires:       python%{python3_pkgversion}-opentelemetry_exporter_otlp_proto_common = 1.19.0
 
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
@@ -63,6 +63,9 @@ set -ex
 
 
 %changelog
+* Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 1.19.0-3
+- Update opentelemetry dependency names
+
 * Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 1.19.0-2
 - Update googleapis-common-protos requirement
 

--- a/packages/python-opentelemetry_exporter_otlp_proto_http/python-opentelemetry_exporter_otlp_proto_http.spec
+++ b/packages/python-opentelemetry_exporter_otlp_proto_http/python-opentelemetry_exporter_otlp_proto_http.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.19.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        OpenTelemetry Collector Protobuf over HTTP Exporter
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -31,12 +31,12 @@ Requires:       python%{python3_pkgversion}-googleapis-common-protos >= 1.52
 Requires:       python%{python3_pkgversion}-googleapis-common-protos < 2
 Requires:       python%{python3_pkgversion}-grpcio >= 1.0.0
 Requires:       python%{python3_pkgversion}-grpcio < 2.0.0
-Requires:       python%{python3_pkgversion}-opentelemetry-api >= 1.15.0
-Requires:       python%{python3_pkgversion}-opentelemetry-api < 2.0.0
-Requires:       python%{python3_pkgversion}-opentelemetry-proto = 1.19.0
-Requires:       python%{python3_pkgversion}-opentelemetry-sdk  >= 1.19.0
-Requires:       python%{python3_pkgversion}-opentelemetry-sdk  < 2.0.0
-Requires:       python%{python3_pkgversion}-opentelemetry-exporter-otlp-proto-common = 1.19.0
+Requires:       python%{python3_pkgversion}-opentelemetry_api >= 1.15.0
+Requires:       python%{python3_pkgversion}-opentelemetry_api < 2.0.0
+Requires:       python%{python3_pkgversion}-opentelemetry_proto = 1.19.0
+Requires:       python%{python3_pkgversion}-opentelemetry_sdk  >= 1.19.0
+Requires:       python%{python3_pkgversion}-opentelemetry_sdk  < 2.0.0
+Requires:       python%{python3_pkgversion}-opentelemetry_exporter_otlp_proto_common = 1.19.0
 Requires:       python%{python3_pkgversion}-requests >= 2.7
 Requires:       python%{python3_pkgversion}-requests < 3.0
 
@@ -65,6 +65,9 @@ set -ex
 
 
 %changelog
+* Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 1.19.0-3
+- Update opentelemetry dependency names
+
 * Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 1.19.0-2
 - Update googleapis-common-protos requirement
 

--- a/packages/python-opentelemetry_instrumentation/python-opentelemetry_instrumentation.spec
+++ b/packages/python-opentelemetry_instrumentation/python-opentelemetry_instrumentation.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.40b0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Instrumentation Tools & Auto Instrumentation for OpenTelemetry Python
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -27,8 +27,8 @@ Summary:        %{summary}
 Requires:       python%{python3_pkgversion}-opentelemetry-api >= 1.4
 Requires:       python%{python3_pkgversion}-opentelemetry-api < 2
 Requires:       python%{python3_pkgversion}-setuptools >= 16.0
-Requires:       python%{python3_pkgversion}-opentelemetry-wrapt >= 1.0.0
-Requires:       python%{python3_pkgversion}-opentelemetry-wrapt < 2.0.0
+Requires:       python%{python3_pkgversion}-wrapt >= 1.0.0
+Requires:       python%{python3_pkgversion}-wrapt < 2.0.0
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -55,5 +55,8 @@ set -ex
 %{_bindir}/opentelemetry-instrument
 
 %changelog
+* Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 0.40b0-2
+- Update opentelemetry dependency names
+
 * Wed Jul 26 2023 Odilon Sousa - 0.40b0-1
 - Initial package.

--- a/packages/python-opentelemetry_instrumentation_django/python-opentelemetry_instrumentation_django.spec
+++ b/packages/python-opentelemetry_instrumentation_django/python-opentelemetry_instrumentation_django.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.40b0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OpenTelemetry Instrumentation for Django
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -28,7 +28,7 @@ Requires:  python%{python3_pkgversion}-opentelemetry_api >= 1.12
 Requires:  python%{python3_pkgversion}-opentelemetry_api < 2
 Requires:  python%{python3_pkgversion}-opentelemetry_instrumentation = 0.40b0
 Requires:  python%{python3_pkgversion}-opentelemetry_instrumentation_wsgi = 0.40b0
-Requires:  python%{python3_pkgversion}-opentelemetry_semantic-conventions = 0.40b0
+Requires:  python%{python3_pkgversion}-opentelemetry_semantic_conventions = 0.40b0
 Requires:  python%{python3_pkgversion}-opentelemetry_util_http = 0.40b0
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
@@ -55,5 +55,8 @@ set -ex
 
 
 %changelog
+* Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 0.40b0-2
+- Update opentelemetry dependency names
+
 * Wed Jul 26 2023 Odilon Sousa - 0.40b0-1
 - Initial package.

--- a/packages/python-opentelemetry_instrumentation_wsgi/python-opentelemetry_instrumentation_wsgi.spec
+++ b/packages/python-opentelemetry_instrumentation_wsgi/python-opentelemetry_instrumentation_wsgi.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.40b0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        WSGI Middleware for OpenTelemetry
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -27,7 +27,7 @@ Summary:        %{summary}
 Requires:  python%{python3_pkgversion}-opentelemetry_api >= 1.12
 Requires:  python%{python3_pkgversion}-opentelemetry_api < 2
 Requires:  python%{python3_pkgversion}-opentelemetry_instrumentation = 0.40b0
-Requires:  python%{python3_pkgversion}-opentelemetry_semantic-conventions = 0.40b0
+Requires:  python%{python3_pkgversion}-opentelemetry_semantic_conventions = 0.40b0
 Requires:  python%{python3_pkgversion}-opentelemetry_util_http = 0.40b0
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
@@ -54,5 +54,8 @@ set -ex
 
 
 %changelog
+* Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 0.40b0-2
+- Update opentelemetry dependency names
+
 * Wed Jul 26 2023 Odilon Sousa - 0.40b0-1
 - Initial package.

--- a/packages/python-opentelemetry_proto/python-opentelemetry_proto.spec
+++ b/packages/python-opentelemetry_proto/python-opentelemetry_proto.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.19.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OpenTelemetry Python Proto.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -24,8 +24,8 @@ BuildRequires:  python%{python3_pkgversion}-tomli
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
-Requires:       python%{python3_pkgversion}-opentelemetry-protobuf >= 3.19
-Requires:       python%{python3_pkgversion}-opentelemetry-protobuf < 5.0
+Requires:       python%{python3_pkgversion}-protobuf >= 3.19
+Requires:       python%{python3_pkgversion}-protobuf < 5.0
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -50,5 +50,8 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 1.19.0-2
+- Update opentelemetry dependency names
+
 * Wed Jul 26 2023 Odilon Sousa - 1.19.0-1
 - Initial package.

--- a/packages/python-opentelemetry_sdk/python-opentelemetry_sdk.spec
+++ b/packages/python-opentelemetry_sdk/python-opentelemetry_sdk.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.19.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OpenTelemetry Python SDK
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -24,9 +24,9 @@ BuildRequires:  python%{python3_pkgversion}-tomli
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
-Requires:       python%{python3_pkgversion}-opentelemetry-api >= 1.19
-Requires:       python%{python3_pkgversion}-opentelemetry-api < 2
-Requires:       python%{python3_pkgversion}-opentelemetry-semantic-conventions >= 0.40b0
+Requires:       python%{python3_pkgversion}-opentelemetry_api >= 1.19
+Requires:       python%{python3_pkgversion}-opentelemetry_api < 2
+Requires:       python%{python3_pkgversion}-opentelemetry_semantic_conventions >= 0.40b0
 Requires:       python%{python3_pkgversion}-typing-extensions >= 3.7.4
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
@@ -52,5 +52,8 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 1.19.0-2
+- Update opentelemetry dependency names
+
 * Wed Jul 26 2023 Odilon Sousa - 1.19.0-1
 - Initial package.

--- a/packages/python-pulp-ansible/python-pulp-ansible.spec
+++ b/packages/python-pulp-ansible/python-pulp-ansible.spec
@@ -6,7 +6,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.18.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Epoch:          1
 Summary:        Pulp plugin to manage Ansible content, e.g. roles
 
@@ -40,8 +40,8 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-pulpcore >= 3.25
 Conflicts:      %{?scl_prefix}python%{python3_pkgversion}-pulpcore >= 3.40
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-semantic-version >= 2.9
 Conflicts:      %{?scl_prefix}python%{python3_pkgversion}-semantic-version >= 2.11
-Requires:       %{?scl_prefix}python%{python3_pkgversion}-semantic-version >= 7.0
-Conflicts:      %{?scl_prefix}python%{python3_pkgversion}-semantic-version >= 9.6
+Requires:       %{?scl_prefix}python%{python3_pkgversion}-pillow >= 7.0
+Conflicts:      %{?scl_prefix}python%{python3_pkgversion}-pillow >= 9.6
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
 
 Provides:       pulpcore-plugin(ansible) = %{version}
@@ -85,6 +85,9 @@ set -ex
 
 
 %changelog
+* Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 1:0.18.0-2
+- Add python-pillow as dependency
+
 * Thu Jul 27 2023 Odilon Sousa <osousa@redhat.com> - 1:0.18.0-1
 - Release python-pulp-ansible 0.18.0
 

--- a/packages/python-pulpcore/python-pulpcore.spec
+++ b/packages/python-pulpcore/python-pulpcore.spec
@@ -2,6 +2,7 @@
 %{!?scl:%global pkg_name %{name}}
 %{!?_root_bindir:%global _root_bindir %{_bindir}}
 %{!?_root_libexecdir:%global _root_libexecdir %{_libexecdir}}
+%{?python_disable_dependency_generator}
 
 # Created by pyp2rpm-3.3.3
 %global pypi_name pulpcore
@@ -10,7 +11,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.28.10
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Pulp Django Application and Related Modules
 
 License:        GPLv2+
@@ -54,8 +55,6 @@ Conflicts:      %{?scl_prefix}python%{python3_pkgversion}-backoff >= 2.2.2
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-click >= 8.1.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-click <= 8.1.3
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-cryptography >= 38.0.1
-Requires:       %{?scl_prefix}python%{python3_pkgversion}-django-currentuser >= 0.5.3
-Conflicts:      %{?scl_prefix}python%{python3_pkgversion}-django-currentuser >= 0.6
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-django-filter >= 23.1
 Conflicts:      %{?scl_prefix}python%{python3_pkgversion}-django-filter >= 23.2
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-django-guid >= 3.3
@@ -192,6 +191,9 @@ done
 
 
 %changelog
+* Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 3.28.10-2
+- Remove python-django-currentuser dependency
+
 * Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 3.28.10-1
 - Release python-pulpcore 3.28.10
 


### PR DESCRIPTION
Also dropping galaxy_ng and the dependencies that are only used by galaxy_ng