### PR TITLE
Fix opentelemetry requirements for Repoclosure on 3.28 branching

### DIFF
--- a/comps/comps-pulpcore-el8.xml
+++ b/comps/comps-pulpcore-el8.xml
@@ -85,7 +85,6 @@
       <packagereq type="default">python39-distro</packagereq>
       <packagereq type="default">python39-distlib</packagereq>
       <packagereq type="default">python39-django</packagereq>
-      <packagereq type="default">python39-django-automated-logging</packagereq>
       <packagereq type="default">python39-django-auth-ldap</packagereq>      
       <packagereq type="default">python39-django-cleanup</packagereq>
       <packagereq type="default">python39-django-filter</packagereq>

--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -274,7 +274,7 @@
       <packagereq type="default">python3-toml</packagereq>
       <packagereq type="default">python3-tomli</packagereq>
       <packagereq type="default">python3-tomli_w</packagereq>
-      <packagereq type="default">python3python-tomlkit</packagereq>
+      <packagereq type="default">python3-tomlkit</packagereq>
       <packagereq type="default">python3-trove-classifiers</packagereq>
       <packagereq type="default">python3-types-cryptography</packagereq>
       <packagereq type="default">python3-typing-extensions</packagereq>

--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -85,7 +85,6 @@
       <packagereq type="default">python3-distlib</packagereq>
       <packagereq type="default">python3-distro</packagereq>
       <packagereq type="default">python3-django</packagereq>
-      <packagereq type="default">python3-django-automated-logging</packagereq>
       <packagereq type="default">python3-django-auth-ldap</packagereq>
       <packagereq type="default">python3-django-cleanup</packagereq>
       <packagereq type="default">python3-django-filter</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -123,7 +123,6 @@ pulpcore_packages:
     python-distlib: {}
     python-distro: {}
     python-django: {}
-    python-django-automated-logging: {}
     python-django-auth-ldap: {}
     python-django-cleanup: {}
     python-django-filter: {}

--- a/packages/python-opentelemetry_distro/python-opentelemetry_distro.spec
+++ b/packages/python-opentelemetry_distro/python-opentelemetry_distro.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.40b0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        OpenTelemetry Python Distro
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -26,7 +26,7 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       python%{python3_pkgversion}-opentelemetry_api >= 1.12
 Requires:       python%{python3_pkgversion}-opentelemetry_api < 2
-Requires:       python%{python3_pkgversion}-opentelemetry_instrumentation == 0.41b0.dev
+Requires:       python%{python3_pkgversion}-opentelemetry_instrumentation == 0.40b0.dev
 Requires:       python%{python3_pkgversion}-opentelemetry_sdk >= 1.13
 Requires:       python%{python3_pkgversion}-opentelemetry_sdk < 2
 
@@ -53,6 +53,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Wed Aug 09 2023 Odilon Sousa <osousa@redhat.com> - 0.40b0-3
+- Update opentelemetry_instrumentation requirement
+
 * Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 0.40b0-2
 - Update opentelemetry dependency names
 

--- a/packages/python-opentelemetry_instrumentation/python-opentelemetry_instrumentation.spec
+++ b/packages/python-opentelemetry_instrumentation/python-opentelemetry_instrumentation.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.40b0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Instrumentation Tools & Auto Instrumentation for OpenTelemetry Python
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -24,8 +24,8 @@ BuildRequires:  python%{python3_pkgversion}-tomli
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
-Requires:       python%{python3_pkgversion}-opentelemetry-api >= 1.4
-Requires:       python%{python3_pkgversion}-opentelemetry-api < 2
+Requires:       python%{python3_pkgversion}-opentelemetry_api >= 1.4
+Requires:       python%{python3_pkgversion}-opentelemetry_api < 2
 Requires:       python%{python3_pkgversion}-setuptools >= 16.0
 Requires:       python%{python3_pkgversion}-wrapt >= 1.0.0
 Requires:       python%{python3_pkgversion}-wrapt < 2.0.0
@@ -55,6 +55,9 @@ set -ex
 %{_bindir}/opentelemetry-instrument
 
 %changelog
+* Wed Aug 09 2023 Odilon Sousa <osousa@redhat.com> - 0.40b0-3
+- Update opentelemetry_api requirement
+
 * Tue Aug 08 2023 Odilon Sousa <osousa@redhat.com> - 0.40b0-2
 - Update opentelemetry dependency names
 


### PR DESCRIPTION
```
[2023-08-09T13:25:09.180Z] fatal: [pulpcore-repoclosure-el8]: FAILED! => changed=true 
[2023-08-09T13:25:09.180Z]   cmd:
[2023-08-09T13:25:09.180Z]   - dnf
[2023-08-09T13:25:09.180Z]   - repoclosure
[2023-08-09T13:25:09.180Z]   - --config
[2023-08-09T13:25:09.180Z]   - /tmp/ansible.njq3_Brepoclosure/yum.conf
[2023-08-09T13:25:09.180Z]   - --refresh
[2023-08-09T13:25:09.180Z]   - --newest
[2023-08-09T13:25:09.180Z]   - --check
[2023-08-09T13:25:09.180Z]   - el8-pulpcore-3.28
[2023-08-09T13:25:09.180Z]   - --check
[2023-08-09T13:25:09.180Z]   - downloaded_rpms
[2023-08-09T13:25:09.180Z]   - --repo
[2023-08-09T13:25:09.180Z]   - el8-baseos
[2023-08-09T13:25:09.180Z]   - --repo
[2023-08-09T13:25:09.180Z]   - el8-appstream
[2023-08-09T13:25:09.180Z]   - --repo
[2023-08-09T13:25:09.180Z]   - el8-powertools
[2023-08-09T13:25:09.180Z]   delta: '0:01:52.626990'
[2023-08-09T13:25:09.180Z]   end: '2023-08-09 13:25:08.982252'
[2023-08-09T13:25:09.180Z]   msg: non-zero return code
[2023-08-09T13:25:09.180Z]   rc: 1
[2023-08-09T13:25:09.180Z]   start: '2023-08-09 13:23:16.355262'
[2023-08-09T13:25:09.181Z]   stderr: |-
[2023-08-09T13:25:09.181Z]     Module yaml error: Unexpected key in component
[2023-08-09T13:25:09.181Z]     Module defaults error: Unexpected key in component
[2023-08-09T13:25:09.181Z]     Error: Repoclosure ended with unresolved dependencies.
[2023-08-09T13:25:09.181Z]   stderr_lines: <omitted>
[2023-08-09T13:25:09.181Z]   stdout: |-
[2023-08-09T13:25:09.181Z]     Last metadata expiration check: 0:00:01 ago on Wed Aug  9 13:24:58 2023.
[2023-08-09T13:25:09.181Z]     package: python39-django-automated-logging-6.1.3-3.el8.noarch from el8-pulpcore-3.28
[2023-08-09T13:25:09.181Z]       unresolved deps:
[2023-08-09T13:25:09.181Z]         python39-django < 4.0
[2023-08-09T13:25:09.181Z]     package: python39-opentelemetry_distro-0.40b0-2.el8.noarch from el8-pulpcore-3.28
[2023-08-09T13:25:09.181Z]       unresolved deps:
[2023-08-09T13:25:09.181Z]         python39-opentelemetry_instrumentation = 0.41b0.dev
[2023-08-09T13:25:09.181Z]     package: python39-opentelemetry_instrumentation-0.40b0-2.el8.noarch from el8-pulpcore-3.28
[2023-08-09T13:25:09.181Z]       unresolved deps:
[2023-08-09T13:25:09.181Z]         python39-opentelemetry-api >= 1.4
[2023-08-09T13:25:09.181Z]         python39-opentelemetry-api < 2
[2023-08-09T13:25:09.181Z]   stdout_lines: <omitted>
```