### PR TITLE
Pin the obsolete version of django-currentuser

### DIFF
--- a/packages/pulpcore-obsolete-packages/pulpcore-obsolete-packages.spec
+++ b/packages/pulpcore-obsolete-packages/pulpcore-obsolete-packages.spec
@@ -1,14 +1,14 @@
 Name: pulpcore-obsolete-packages
 Version: 1.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: MIT
 Summary: A package to obsolete retired packages
 URL: https://github.com/theforeman/pulpcore-packaging
 BuildArch: noarch
 
-Obsoletes:      python3-django-currentuser
+Obsoletes:      python3-django-currentuser < 0.5.3-6
 %if 0%{?rhel} == 8
-Obsoletes:      python39-django-currentuser
+Obsoletes:      python39-django-currentuser < 0.5.3-6
 %endif
 
 %description
@@ -24,5 +24,8 @@ from the distribution for some reason.
 %files
 
 %changelog
+* Mon Aug 28 2023 Odilon Sousa <osousa@redhat.com> - 1.0-2
+- Pin the version of django-currentuser
+
 * Tue Aug 15 2023 Zach Huntington-Meath <zhunting@redhat.com> - 1.0-1
 - Initial package


### PR DESCRIPTION
This ensures that it's possible to add a new version of the package in the future