### PR TITLE
Python 3.9 obsoletes m through p

### DIFF
--- a/packages/python-markdown/python-markdown.spec
+++ b/packages/python-markdown/python-markdown.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        3.4.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Python implementation of Markdown
 
 License:        BSD License
@@ -30,6 +30,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-importlib-metadata >= 4.4
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -68,6 +72,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.4.1-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.4.1-2
 - Build against python 3.11
 

--- a/packages/python-markuppy/python-markuppy.spec
+++ b/packages/python-markuppy/python-markuppy.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        1.14
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        An HTML/XML generator
 
 License:        MIT
@@ -28,6 +28,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -63,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.14-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.14-4
 - Build against python 3.11
 

--- a/packages/python-markupsafe/python-markupsafe.spec
+++ b/packages/python-markupsafe/python-markupsafe.spec
@@ -17,7 +17,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        2.1.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Safely add untrusted strings to HTML/XML markup
 
 License:        BSD-3-Clause
@@ -35,6 +35,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -96,6 +100,9 @@ CFLAGS="${CFLAGS:-${RPM_OPT_FLAGS}}" LDFLAGS="${LDFLAGS:-${RPM_LD_FLAGS}}"\
 %endif
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.1.2-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.1.2-2
 - Build against python 3.11
 

--- a/packages/python-marshmallow/python-marshmallow.spec
+++ b/packages/python-marshmallow/python-marshmallow.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.13.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A lightweight library for converting complex datatypes to and from native Python datatypes
 
 License:        MIT
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.13.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.13.0-3
 - Build against python 3.11
 

--- a/packages/python-mccabe/python-mccabe.spec
+++ b/packages/python-mccabe/python-mccabe.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.7.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        McCabe checker, plugin for flake8
 
 License:        Expat license
@@ -28,6 +28,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -68,6 +72,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.7.0-2
+- Add python39 obsoletes to package
+
 * Mon Nov 20 2023 Patrick Creech <pcreech@redhat.com> - 0.7.0-1
 - Release python-mccabe 0.7.0
 

--- a/packages/python-mongoengine/python-mongoengine.spec
+++ b/packages/python-mongoengine/python-mongoengine.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.20.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        MongoEngine is a Python Object-Document Mapper for working with MongoDB
 
 License:        MIT
@@ -29,6 +29,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-pymongo < 4.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-pymongo >= 3.4
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -66,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.20.0-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.20.0-4
 - Build against python 3.11
 

--- a/packages/python-more-itertools/python-more-itertools.spec
+++ b/packages/python-more-itertools/python-more-itertools.spec
@@ -4,7 +4,7 @@
 
 Name:           python-%{pypi_name}
 Version:        9.1.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        This is the extensible, standards compliant build backend used by Hatch.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -25,6 +25,9 @@ BuildRequires:  pyproject-rpm-macros
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
@@ -50,6 +53,9 @@ set -ex
 %{python3_sitelib}/more_itertools-%{version}.dist-info/
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 9.1.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 9.1.0-2
 - Build against python 3.11
 

--- a/packages/python-msgpack/python-msgpack.spec
+++ b/packages/python-msgpack/python-msgpack.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.0.5
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        MessagePack serializer
 
 License:        Apache 2.0
@@ -26,6 +26,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -62,6 +65,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.0.5-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.0.5-2
 - Build against python 3.11
 

--- a/packages/python-msrest/python-msrest.spec
+++ b/packages/python-msrest/python-msrest.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.6.21
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        AutoRest swagger generator Python client runtime
 
 License:        MIT License
@@ -32,6 +32,9 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-isodate >= 0.6
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-requests < 3
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-requests >= 2.16
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-requests-oauthlib >= 0.5
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -67,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.6.21-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.6.21-3
 - Build against python 3.11
 

--- a/packages/python-multidict/python-multidict.spec
+++ b/packages/python-multidict/python-multidict.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        6.0.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        multidict implementation
 
 License:        Apache 2
@@ -27,6 +27,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -63,6 +66,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 6.0.4-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 6.0.4-2
 - Build against python 3.11
 

--- a/packages/python-naya/python-naya.spec
+++ b/packages/python-naya/python-naya.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.1.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        A fast streaming JSON parser written in pure python
 
 License:        MIT
@@ -32,6 +32,9 @@ Obsoletes:      python38-%{pypi_name} < %{version}-%{release}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -67,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.1.1-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.1.1-4
 - Build against python 3.11
 

--- a/packages/python-oauthlib/python-oauthlib.spec
+++ b/packages/python-oauthlib/python-oauthlib.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.1.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A generic, spec-compliant, thorough implementation of the OAuth request-signing logic
 
 License:        BSD
@@ -28,6 +28,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -64,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.1.1-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.1.1-3
 - Build against python 3.11
 

--- a/packages/python-odfpy/python-odfpy.spec
+++ b/packages/python-odfpy/python-odfpy.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.4.1
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        Python API and tools to manipulate OpenDocument files
 
 License:        GPLv2+ or Apache-2.0
@@ -29,6 +29,9 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-defusedxml
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -87,6 +90,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.4.1-8
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.4.1-7
 - Build against python 3.11
 

--- a/packages/python-openpyxl/python-openpyxl.spec
+++ b/packages/python-openpyxl/python-openpyxl.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.1.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A Python library to read/write Excel 2010 xlsx/xlsm files
 
 License:        MIT
@@ -29,6 +29,9 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-et-xmlfile
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -64,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.1.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.1.0-2
 - Build against python 3.11
 

--- a/packages/python-packaging/python-packaging.spec
+++ b/packages/python-packaging/python-packaging.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        21.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Core utilities for Python packages
 
 License:        BSD-2-Clause or Apache-2.0
@@ -30,6 +30,9 @@ Summary:        %{summary}
 Conflicts:      %{?scl_prefix}python%{python3_pkgversion}-pyparsing = 3.0.5
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-pyparsing >= 2.0.2
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -66,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 21.3-4
+- Add python39 obsoletes to package
+
 * Wed Nov 15 2023 Patrick Creech <pcreech@redhat.com> - 21.3-3
 - Conflict with pyparsing 3.0.5 instead 
 

--- a/packages/python-parsley/python-parsley.spec
+++ b/packages/python-parsley/python-parsley.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        1.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Parsing and pattern matching made easy
 
 License:        MIT License
@@ -30,6 +30,9 @@ Summary:        %{summary}
 Provides:       %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name} = %{version}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 %{summary}
@@ -67,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.3-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.3-3
 - Build against python 3.11
 

--- a/packages/python-pathspec/python-pathspec.spec
+++ b/packages/python-pathspec/python-pathspec.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.11.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Utility library for gitignore style pattern matching of file paths
 
 License:        MPL 2.0
@@ -28,6 +28,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools >= 40.8
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -63,6 +66,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.11.1-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.11.1-2
 - Build against python 3.11
 

--- a/packages/python-pbr/python-pbr.spec
+++ b/packages/python-pbr/python-pbr.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        5.8.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Python Build Reasonableness
 
 License:        None
@@ -29,6 +29,9 @@ BuildArch:      noarch
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -66,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 5.8.0-6
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 5.8.0-5
 - Build against python 3.11
 

--- a/packages/python-pexpect/python-pexpect.spec
+++ b/packages/python-pexpect/python-pexpect.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        4.8.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Pexpect allows easy control of interactive console applications
 
 License:        ISC license
@@ -28,6 +28,9 @@ BuildArch:      noarch
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       python%{python3_pkgversion}-ptyprocess
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 4.8.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 4.8.0-3
 - Build against python 3.11
 

--- a/packages/python-pillow/python-pillow.spec
+++ b/packages/python-pillow/python-pillow.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        9.5.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Python Imaging Library (Fork)
 
 License:        HPND
@@ -29,7 +29,9 @@ BuildRequires:  libjpeg-turbo-devel
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
-
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -67,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 9.5.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 9.5.0-2
 - Build against python 3.11
 

--- a/packages/python-platformdirs/python-platformdirs.spec
+++ b/packages/python-platformdirs/python-platformdirs.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        3.10.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A small Python module for determining appropriate platform-specific dirs, e
 
 License:        MIT
@@ -30,6 +30,10 @@ BuildRequires:  python%{python3_pkgversion}-tomli
 %package -n    python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -54,6 +58,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.10.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.10.0-2
 - Build against python 3.11
 

--- a/packages/python-pluggy/python-pluggy.spec
+++ b/packages/python-pluggy/python-pluggy.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.3.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        plugin and hook calling mechanisms for python
 
 License:        MIT
@@ -31,6 +31,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-typing-extensions
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -68,6 +72,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.3.0-2
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.3.0-1
 - Release python-pluggy 1.3.0
 

--- a/packages/python-poetry/python-poetry.spec
+++ b/packages/python-poetry/python-poetry.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.5.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Python dependency management and packaging made easy.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -60,6 +60,10 @@ Requires:       python%{python3_pkgversion}-tomlkit >= 0.11.4
 Requires:       python%{python3_pkgversion}-trove-classifiers >= 2022.5.19
 Requires:       python%{python3_pkgversion}-urllib3 >= 1.26.0
 Requires:       python%{python3_pkgversion}-virtualenv >= 20.22.0
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -85,6 +89,9 @@ set -ex
 %{_bindir}/%{pypi_name}
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.5.1-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.5.1-3
 - Build against python 3.11
 

--- a/packages/python-poetry_core/python-poetry_core.spec
+++ b/packages/python-poetry_core/python-poetry_core.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.6.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Poetry PEP 517 Build Backend
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -29,6 +29,10 @@ Summary:        %{summary}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-tomli
 Requires:       pyproject-rpm-macros
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-pip
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -53,6 +57,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.6.1-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.6.1-3
 - Build against python 3.11
 

--- a/packages/python-poetry_plugin_export/python-poetry_plugin_export.spec
+++ b/packages/python-poetry_plugin_export/python-poetry_plugin_export.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.4.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Poetry plugin to export the dependencies to various formats
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -29,6 +29,10 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-poetry >= 1.5
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-poetry < 2.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-poetry_core >= 1.6
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-poetry_core < 2.0
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -53,6 +57,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.4.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.4.0-2
 - Build against python 3.11
 

--- a/packages/python-productmd/python-productmd.spec
+++ b/packages/python-productmd/python-productmd.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.33
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Product, compose and installation media metadata library
 
 License:        LGPLv2.1
@@ -28,6 +28,9 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -64,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.33-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.33-4
 - Build against python 3.11
 

--- a/packages/python-prometheus-client/python-prometheus-client.spec
+++ b/packages/python-prometheus-client/python-prometheus-client.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.8.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Python client for the Prometheus monitoring system
 
 License:        Apache Software License 2.0
@@ -28,6 +28,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -63,6 +66,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.8.0-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.8.0-4
 - Build against python 3.11
 

--- a/packages/python-protobuf/python-protobuf.spec
+++ b/packages/python-protobuf/python-protobuf.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        4.21.6
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Protocol Buffers
 
 License:        BSD-3-Clause
@@ -27,6 +27,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 4.21.6-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 4.21.6-2
 - Build against python 3.11
 

--- a/packages/python-psycopg/python-psycopg.spec
+++ b/packages/python-psycopg/python-psycopg.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.1.9
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        PostgreSQL database adapter for Python
 
 License:        GNU Lesser General Public License v3 (LGPLv3)
@@ -29,6 +29,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-wheel >= 0.37
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-typing-extensions >= 4.1
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -66,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.1.9-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.1.9-2
 - Build against python 3.11
 

--- a/packages/python-psycopg2/python-psycopg2.spec
+++ b/packages/python-psycopg2/python-psycopg2.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.9.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        psycopg2 - Python-PostgreSQL Database Adapter
 
 License:        LGPL with exceptions
@@ -28,6 +28,9 @@ BuildRequires:  postgresql-devel
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -64,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.9.3-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.9.3-3
 - Build against python 3.11
 

--- a/packages/python-ptyprocess/python-ptyprocess.spec
+++ b/packages/python-ptyprocess/python-ptyprocess.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.7.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Run a subprocess in a pseudo terminal
 
 License:        None
@@ -27,6 +27,10 @@ BuildRequires:  python%{python3_pkgversion}-setuptools
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
@@ -62,6 +66,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.7.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.7.0-2
 - Build against python 3.11
 

--- a/packages/python-pyOpenSSL/python-pyOpenSSL.spec
+++ b/packages/python-pyOpenSSL/python-pyOpenSSL.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        22.1.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Python wrapper module around the OpenSSL library
 
 License:        Apache License, Version 2.0
@@ -30,6 +30,9 @@ Summary:        %{summary}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-cryptography >= 38.0.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six >= 1.5.2
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -66,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 22.1.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 22.1.0-2
 - Build against python 3.11
 

--- a/packages/python-pyasn1-modules/python-pyasn1-modules.spec
+++ b/packages/python-pyasn1-modules/python-pyasn1-modules.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.2.8
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A collection of ASN.1-based protocols modules
 
 License:        BSD-2-Clause
@@ -30,6 +30,9 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-pyasn1 >= 0.4.6
 Conflicts:       %{?scl_prefix}python%{python3_pkgversion}-pyasn1 > 0.6
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -66,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.2.8-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.2.8-2
 - Build against python 3.11
 

--- a/packages/python-pyasn1/python-pyasn1.spec
+++ b/packages/python-pyasn1/python-pyasn1.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.4.8
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        ASN.1 types and codecs
 
 License:        BSD
@@ -28,6 +28,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -64,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.4.8-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.4.8-2
 - Build against python 3.11
 

--- a/packages/python-pycairo/python-pycairo.spec
+++ b/packages/python-pycairo/python-pycairo.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.20.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Python interface for cairo
 
 License:        LGPL-2.1-only OR MPL-1.1
@@ -27,6 +27,9 @@ BuildRequires:  cairo-devel
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -78,6 +81,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.20.1-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.20.1-4
 - Build against python 3.11
 

--- a/packages/python-pycares/python-pycares.spec
+++ b/packages/python-pycares/python-pycares.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        4.1.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Python interface for c-ares
 
 License:        MIT
@@ -30,6 +30,9 @@ Summary:        %{summary}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-cffi >= 1.5.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-idna >= 2.1
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -66,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 4.1.2-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 4.1.2-3
 - Build against python 3.11
 

--- a/packages/python-pycodestyle/python-pycodestyle.spec
+++ b/packages/python-pycodestyle/python-pycodestyle.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.9.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python style guide checker
 
 License:        Expat license
@@ -29,6 +29,9 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -67,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.9.1-2
+- Add python39 obsoletes to package
+
 * Mon Nov 20 2023 Patrick Creech <pcreech@redhat.com> - 2.9.1-1
 - Release python-pycodestyle 2.9.1
 

--- a/packages/python-pycparser/python-pycparser.spec
+++ b/packages/python-pycparser/python-pycparser.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.21
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        C parser in Python
 
 License:        BSD
@@ -29,6 +29,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -65,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.21-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.21-3
 - Build against python 3.11
 

--- a/packages/python-pycryptodomex/python-pycryptodomex.spec
+++ b/packages/python-pycryptodomex/python-pycryptodomex.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.14.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Cryptographic library for Python
 
 License:        BSD, Public Domain
@@ -27,6 +27,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -63,6 +66,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.14.1-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.14.1-3
 - Build against python 3.11
 

--- a/packages/python-pyflakes/python-pyflakes.spec
+++ b/packages/python-pyflakes/python-pyflakes.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.5.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        passive checker of Python programs
 
 License:        MIT
@@ -29,6 +29,9 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -66,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.5.0-2
+- Add python39 obsoletes to package
+
 * Mon Nov 20 2023 Patrick Creech <pcreech@redhat.com> - 2.5.0-1
 - Release python-pyflakes 2.5.0
 

--- a/packages/python-pygments/python-pygments.spec
+++ b/packages/python-pygments/python-pygments.spec
@@ -10,7 +10,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        2.14.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Pygments is a syntax highlighting package written in Python
 
 License:        BSD
@@ -28,6 +28,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 %{summary}
@@ -65,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.14.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.14.0-2
 - Build against python 3.11
 

--- a/packages/python-pygobject/python-pygobject.spec
+++ b/packages/python-pygobject/python-pygobject.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        3.40.1
-Release:        5%{?dist}
+Release:        6%{?dist}
 Epoch:          1
 Summary:        Python bindings for GObject Introspection
 
@@ -38,6 +38,7 @@ Obsoletes:      python3-%{pypi_name} < %{version}-%{release}
 %endif
 %if 0%{?rhel} == 8
 Obsoletes:      python38-%{srcname} < %{epoch}:%{version}-%{release}
+Obsoletes:      python39-%{srcname} < %{epoch}:%{version}-%{release}
 %endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -78,6 +79,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1:3.40.1-6
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1:3.40.1-5
 - Build against python 3.11
 

--- a/packages/python-pygtrie/python-pygtrie.spec
+++ b/packages/python-pygtrie/python-pygtrie.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.5.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A pure Python trie data structure implementation
 
 License:        Apache-2.0
@@ -28,6 +28,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -62,6 +65,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.5.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.5.0-2
 - Build against python 3.11
 

--- a/packages/python-pyjwkest/python-pyjwkest.spec
+++ b/packages/python-pyjwkest/python-pyjwkest.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.4.2
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        Python implementation of JWT, JWE, JWS and JWK
 
 License:        Apache 2.0
@@ -32,6 +32,9 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-pycryptodomex
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-requests
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -74,6 +77,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.4.2-8
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.4.2-7
 - Build against python 3.11
 

--- a/packages/python-pyjwt/python-pyjwt.spec
+++ b/packages/python-pyjwt/python-pyjwt.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        2.5.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        JSON Web Token implementation in Python
 
 License:        MIT
@@ -32,6 +32,9 @@ Obsoletes:      %{?scl_prefix}python%{python3_pkgversion}-jwt < %{version}-%{rel
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-cryptography >= 3.3.1
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-types-cryptography >= 3.3.21
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 %{summary}
@@ -69,6 +72,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.5.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.5.0-3
 - Build against python 3.11
 

--- a/packages/python-pymongo/python-pymongo.spec
+++ b/packages/python-pymongo/python-pymongo.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.11.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Python driver for MongoDB
 
 License:        Apache License, Version 2.0
@@ -27,6 +27,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -65,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.11.0-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.11.0-4
 - Build against python 3.11
 

--- a/packages/python-pyparsing/python-pyparsing.spec
+++ b/packages/python-pyparsing/python-pyparsing.spec
@@ -10,7 +10,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.1.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python parsing module
 
 License:        MIT License
@@ -30,6 +30,9 @@ BuildRequires:  pyproject-rpm-macros
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -54,6 +57,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.1.1-2
+- Add python39 obsoletes to package
+
 * Tue Nov 14 2023 Odilon Sousa <osousa@redhat.com> - 3.1.1-1
 - Release python-pyparsing 3.1.1
 

--- a/packages/python-pyperclip/python-pyperclip.spec
+++ b/packages/python-pyperclip/python-pyperclip.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.8.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A cross-platform clipboard module for Python. (Only handles plain text for now
 
 License:        BSD
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.8.2-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.8.2-2
 - Build against python 3.11
 

--- a/packages/python-pypi-simple/python-pypi-simple.spec
+++ b/packages/python-pypi-simple/python-pypi-simple.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.9.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        PyPI Simple Repository API client library
 
 License:        MIT
@@ -30,6 +30,9 @@ Requires:  %{?scl_prefix}python%{python3_pkgversion}-packaging
 Requires:  %{?scl_prefix}python%{python3_pkgversion}-requests
 Requires:  %{?scl_prefix}python%{python3_pkgversion}-beautifulsoup4
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -68,6 +71,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.9.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.9.0-3
 - Build against python 3.11
 

--- a/packages/python-pyproject_hooks/python-pyproject_hooks.spec
+++ b/packages/python-pyproject_hooks/python-pyproject_hooks.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.0.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Wrappers to call pyproject.toml-based build backend hooks.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -25,6 +25,10 @@ BuildRequires:  python%{python3_pkgversion}-flit_core
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -49,6 +53,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.0.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.0.0-2
 - Build against python 3.11
 

--- a/packages/python-pyrsistent/python-pyrsistent.spec
+++ b/packages/python-pyrsistent/python-pyrsistent.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.18.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Persistent/Functional/Immutable data structures
 
 License:        MIT
@@ -27,6 +27,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -65,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.18.1-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.18.1-3
 - Build against python 3.11
 

--- a/packages/python-python3-openid/python-python3-openid.spec
+++ b/packages/python-python3-openid/python-python3-openid.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.2.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        OpenID support for modern servers and consumers
 
 License:        None
@@ -29,6 +29,9 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-defusedxml
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -65,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.2.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.2.0-3
 - Build against python 3.11
 

--- a/packages/python-pytz/python-pytz.spec
+++ b/packages/python-pytz/python-pytz.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2022.2.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        World timezone definitions, modern and historical
 
 License:        MIT
@@ -28,6 +28,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -64,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2022.2.1-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2022.2.1-3
 - Build against python 3.11
 

--- a/packages/python-pyyaml/python-pyyaml.spec
+++ b/packages/python-pyyaml/python-pyyaml.spec
@@ -10,7 +10,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        5.4.1
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        YAML parser and emitter for Python
 
 License:        MIT
@@ -36,6 +36,9 @@ Provides:       %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name} = %{versi
 %{?python_provide:%python_provide python%{python3_pkgversion}-yaml}
 Provides:       %{?scl_prefix}python%{python3_pkgversion}-yaml = %{version}-%{release}
 
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 %{summary}
@@ -72,6 +75,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 5.4.1-6
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 5.4.1-5
 - Build against python 3.11
 


### PR DESCRIPTION
(cherry picked from commit dd1209c51c27131d6e051351464115cd84ee8965)