### PR TITLE
Python 3.9 obsoletes e through l

### DIFF
--- a/packages/python-ecdsa/python-ecdsa.spec
+++ b/packages/python-ecdsa/python-ecdsa.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.18.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        ECDSA cryptographic signature library (pure python)
 
 License:        MIT
@@ -26,6 +26,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -62,6 +66,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.18.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.18.0-2
 - Build against python 3.11
 

--- a/packages/python-editables/python-editables.spec
+++ b/packages/python-editables/python-editables.spec
@@ -4,7 +4,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Editable installations
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -27,6 +27,9 @@ BuildRequires:  pyproject-rpm-macros
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
@@ -53,6 +56,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.4-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.4-2
 - Build against python 3.11
 

--- a/packages/python-et-xmlfile/python-et-xmlfile.spec
+++ b/packages/python-et-xmlfile/python-et-xmlfile.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.1.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        An implementation of lxml.xmlfile for the standard library
 
 License:        MIT
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -63,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.1.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.1.0-3
 - Build against python 3.11
 

--- a/packages/python-exceptiongroup/python-exceptiongroup.spec
+++ b/packages/python-exceptiongroup/python-exceptiongroup.spec
@@ -4,7 +4,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.1.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Backport of PEP 654 (exception groups)
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -26,6 +26,9 @@ BuildRequires:  python%{python3_pkgversion}-flit_scm
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
@@ -52,6 +55,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.1.2-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.1.2-2
 - Build against python 3.11
 

--- a/packages/python-filecache/python-filecache.spec
+++ b/packages/python-filecache/python-filecache.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.81
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Persistent caching decorator
 
 License:        None
@@ -27,6 +27,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -63,6 +66,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.81-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.81-2
 - Build against python 3.11
 

--- a/packages/python-filelock/python-filelock.spec
+++ b/packages/python-filelock/python-filelock.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.8.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A platform independent file lock
 
 License:        Unlicense
@@ -28,6 +28,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools-scm
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.8.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.8.0-2
 - Build against python 3.11
 

--- a/packages/python-flit-core/python-flit-core.spec
+++ b/packages/python-flit-core/python-flit-core.spec
@@ -7,7 +7,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.9.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Distribution-building parts of Flit. See flit package for more information
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -33,6 +33,9 @@ Summary:        %{summary}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-tomli
 Requires:       pyproject-rpm-macros
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-pip
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -60,6 +63,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.9.0-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.9.0-4
 - Build against python 3.11
 

--- a/packages/python-flit/python-flit.spec
+++ b/packages/python-flit/python-flit.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.9.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Distribution-building parts of Flit. See flit package for more information
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -34,6 +34,9 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-tomli_w
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-requests
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-docutils
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-flit_core
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -62,6 +65,9 @@ set -ex
 %{_bindir}/flit
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.9.0-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.9.0-4
 - Build against python 3.11
 

--- a/packages/python-flit_scm/python-flit_scm.spec
+++ b/packages/python-flit_scm/python-flit_scm.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.7.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A PEP 518 build backend that uses setuptools_scm to generate a version file from your version control system, then flit_core to build the package.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -34,6 +34,9 @@ Summary:        %{summary}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools-scm
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-tomli
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-flit_core
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -61,6 +64,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.7.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.7.0-3
 - Build against python 3.11
 

--- a/packages/python-frozenlist/python-frozenlist.spec
+++ b/packages/python-frozenlist/python-frozenlist.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.3.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A list-like structure which implements collections
 
 License:        Apache 2
@@ -26,6 +26,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -63,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.3.3-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.3.3-2
 - Build against python 3.11
 

--- a/packages/python-future/python-future.spec
+++ b/packages/python-future/python-future.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.18.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Clean single-source support for Python 3 and 2
 
 License:        MIT
@@ -28,6 +28,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -70,6 +74,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.18.3-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.18.3-2
 - Build against python 3.11
 

--- a/packages/python-gitdb/python-gitdb.spec
+++ b/packages/python-gitdb/python-gitdb.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        4.0.10
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Git Object Database
 
 License:        BSD License
@@ -28,6 +28,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-smmap < 6
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-smmap >= 3.0.1
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 4.0.10-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 4.0.10-2
 - Build against python 3.11
 

--- a/packages/python-gitpython/python-gitpython.spec
+++ b/packages/python-gitpython/python-gitpython.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        3.1.32
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        GitPython is a python library used to interact with Git repositories
 
 License:        BSD
@@ -32,6 +32,10 @@ Requires:       git-core
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-gitdb < 5
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-gitdb >= 4.0.1
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-typing-extensions >= 3.7.4.3
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -69,6 +73,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.1.32-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.1.32-2
 - Build against python 3.11
 

--- a/packages/python-gnupg/python-gnupg.spec
+++ b/packages/python-gnupg/python-gnupg.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        0.5.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A wrapper for the Gnu Privacy Guard (GPG or GnuPG)
 
 License:        BSD-3-Clause
@@ -28,6 +28,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
+
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -68,6 +72,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.5.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.5.0-2
 - Build against python 3.11
 

--- a/packages/python-googleapis-common-protos/python-googleapis-common-protos.spec
+++ b/packages/python-googleapis-common-protos/python-googleapis-common-protos.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.59.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Common protobufs used in Google APIs
 
 License:        Apache-2.0
@@ -47,6 +47,9 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-grpcio < 2.0.0.dev0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-grpcio >= 1.44.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-protobuf < 5.0.0.dev0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-protobuf >= 3.19.5
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -85,6 +88,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.59.1-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.59.1-2
 - Build against python 3.11
 

--- a/packages/python-grpcio/python-grpcio.spec
+++ b/packages/python-grpcio/python-grpcio.spec
@@ -11,7 +11,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        1.56.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        HTTP/2-based RPC framework
 
 License:        Apache License 2.0
@@ -28,6 +28,9 @@ BuildRequires:  python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 %{summary}
@@ -62,6 +65,9 @@ set -ex
 %{python3_sitearch}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.56.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.56.0-2
 - Build against python 3.11
 

--- a/packages/python-h11/python-h11.spec
+++ b/packages/python-h11/python-h11.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.14.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A pure-Python, bring-your-own-I/O implementation of HTTP/1
 
 License:        MIT
@@ -26,6 +26,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -62,6 +65,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.14.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.14.0-2
 - Build against python 3.11
 

--- a/packages/python-hatch/python-hatch.spec
+++ b/packages/python-hatch/python-hatch.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.7.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Modern, extensible Python project management
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -44,6 +44,9 @@ Requires:  python%{python3_pkgversion}-tomlkit >= 0.11.1
 Requires:  python%{python3_pkgversion}-userpath >= 1.7
 Requires:  python%{python3_pkgversion}-userpath < 2.0
 Requires:  python%{python3_pkgversion}-virtualenv >= 20.16.2
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 
@@ -72,6 +75,9 @@ set -ex
 %{_bindir}/%{pypi_name}
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.7.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.7.0-3
 - Build against python 3.11
 

--- a/packages/python-hatch_fancy_pypi_readme/python-hatch_fancy_pypi_readme.spec
+++ b/packages/python-hatch_fancy_pypi_readme/python-hatch_fancy_pypi_readme.spec
@@ -4,7 +4,7 @@
 
 Name:           python-%{pypi_name}
 Version:        23.1.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Fancy PyPI READMEs with Hatch
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -27,6 +27,9 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:  python%{python3_pkgversion}-hatchling
 Requires:  python%{python3_pkgversion}-tomli
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -52,6 +55,9 @@ set -ex
 %{_bindir}/hatch-fancy-pypi-readme
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 23.1.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 23.1.0-2
 - Build against python 3.11
 

--- a/packages/python-hatch_vcs/python-hatch_vcs.spec
+++ b/packages/python-hatch_vcs/python-hatch_vcs.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.3.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Hatch plugin for versioning with your preferred VCS
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -30,6 +30,9 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:  python%{python3_pkgversion}-hatchling
 Requires:  python%{python3_pkgversion}-setuptools-scm
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
@@ -56,6 +59,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.3.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.3.0-3
 - Build against python 3.11
 

--- a/packages/python-hatchling/python-hatchling.spec
+++ b/packages/python-hatchling/python-hatchling.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.18.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        This is the extensible, standards compliant build backend used by Hatch.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -37,6 +37,9 @@ Requires:       python%{python3_pkgversion}-pluggy
 Requires:       python%{python3_pkgversion}-packaging
 Requires:       python%{python3_pkgversion}-trove-classifiers
 Requires:       pyproject-rpm-macros
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -62,6 +65,9 @@ set -ex
 %{_bindir}/%{pypi_name}
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.18.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.18.0-3
 - Build against python 3.11
 

--- a/packages/python-html5lib/python-html5lib.spec
+++ b/packages/python-html5lib/python-html5lib.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        HTML parser based on the WHATWG HTML specification
 
 License:        MIT License
@@ -30,7 +30,9 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six >= 1.9
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-webencodings
-
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -67,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.1-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.1-2
 - Build against python 3.11
 

--- a/packages/python-httpcore/python-httpcore.spec
+++ b/packages/python-httpcore/python-httpcore.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.17.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A minimal low-level HTTP client
 
 License:        BSD
@@ -30,6 +30,9 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-anyio
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-certifi
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-h11
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-sniffio
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -66,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.17.3-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.17.3-2
 - Build against python 3.11
 

--- a/packages/python-httpx/python-httpx.spec
+++ b/packages/python-httpx/python-httpx.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.24.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        The next generation HTTP client.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -32,6 +32,9 @@ Requires:       python%{python3_pkgversion}-httpcore >= 0.15.0
 Requires:       python%{python3_pkgversion}-httpcore < 0.18.0
 Requires:       python%{python3_pkgversion}-idna
 Requires:       python%{python3_pkgversion}-sniffio
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -57,6 +60,9 @@ set -ex
 %{_bindir}/%{pypi_name}
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.24.1-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.24.1-2
 - Build against python 3.11
 

--- a/packages/python-humanfriendly/python-humanfriendly.spec
+++ b/packages/python-humanfriendly/python-humanfriendly.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        10.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Human friendly output for text interfaces using Python
 
 License:        MIT
@@ -26,6 +26,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 10.0-6
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 10.0-5
 - Build against python 3.11
 

--- a/packages/python-hyperlink/python-hyperlink.spec
+++ b/packages/python-hyperlink/python-hyperlink.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        21.0.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A featureful, immutable, and correct URL for Python
 
 License:        MIT
@@ -28,6 +28,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-idna >= 2.5
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 21.0.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 21.0.0-2
 - Build against python 3.11
 

--- a/packages/python-idna-ssl/python-idna-ssl.spec
+++ b/packages/python-idna-ssl/python-idna-ssl.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.1.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Patch ssl.match_hostname for Unicode(idna) domains support
 
 License:        MIT
@@ -28,6 +28,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-idna >= 2.0
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -66,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.1.0-7
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.1.0-6
 - Build against python 3.11
 

--- a/packages/python-idna/python-idna.spec
+++ b/packages/python-idna/python-idna.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Internationalized Domain Names in Applications (IDNA)
 
 License:        BSD-3-Clause
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.3-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.3-3
 - Build against python 3.11
 

--- a/packages/python-importlib-metadata/python-importlib-metadata.spec
+++ b/packages/python-importlib-metadata/python-importlib-metadata.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        6.0.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Read metadata from Python packages
 
 License:        Apache Software License
@@ -28,6 +28,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools-scm
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-zipp >= 0.5
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -66,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 6.0.1-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 6.0.1-2
 - Build against python 3.11
 

--- a/packages/python-importlib-resources/python-importlib-resources.spec
+++ b/packages/python-importlib-resources/python-importlib-resources.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        5.4.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Read resources from Python packages
 
 License:        Apache2
@@ -29,6 +29,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools-scm >= 3.4.
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-zipp >= 3.1.0
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -68,6 +72,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 5.4.0-6
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 5.4.0-5
 - Build against python 3.11
 

--- a/packages/python-inflection/python-inflection.spec
+++ b/packages/python-inflection/python-inflection.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.5.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        A port of Ruby on Rails inflector to Python
 
 License:        MIT
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.5.1-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.5.1-4
 - Build against python 3.11
 

--- a/packages/python-iniparse/python-iniparse.spec
+++ b/packages/python-iniparse/python-iniparse.spec
@@ -10,7 +10,7 @@
 
 Name:           %{?scl_prefix}python-%{modname}
 Version:        0.4
-Release:        36%{?dist}
+Release:        37%{?dist}
 Summary:        Python Module for Accessing and Modifying Configuration Data in INI files
 License:        MIT and Python
 URL:            https://pypi.org/project/iniparse/
@@ -44,6 +44,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-six
 BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-test
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six
 Obsoletes:      %{?scl_prefix}platform-python-%{modname} < %{version}-%{release}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{modname} < %{version}-%{release}
+%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{modname} %{_description}
 
@@ -90,6 +94,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.4-37
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.4-36
 - Build against python 3.11
 

--- a/packages/python-installer/python-installer.spec
+++ b/packages/python-installer/python-installer.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.7.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A library for installing Python wheels.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -25,6 +25,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-flit_core
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -49,6 +52,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.7.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.7.0-2
 - Build against python 3.11
 

--- a/packages/python-isodate/python-isodate.spec
+++ b/packages/python-isodate/python-isodate.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.6.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        An ISO 8601 date/time/duration parser and formatter
 
 License:        BSD
@@ -29,6 +29,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 ISO 8601 date/time parser This module implements ISO 8601 date, time and
@@ -66,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.6.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.6.0-3
 - Build against python 3.11
 

--- a/packages/python-itypes/python-itypes.spec
+++ b/packages/python-itypes/python-itypes.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.2.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Simple immutable types for python
 
 License:        BSD
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.2.0-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.2.0-4
 - Build against python 3.11
 

--- a/packages/python-jaraco-classes/python-jaraco-classes.spec
+++ b/packages/python-jaraco-classes/python-jaraco-classes.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pypi_name}
 Version:        3.2.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Utility functions for Python class constructs
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -29,6 +29,9 @@ BuildRequires:  pyproject-rpm-macros
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       python%{python3_pkgversion}-more-itertools
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -56,6 +59,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.2.3-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.2.3-2
 - Build against python 3.11
 

--- a/packages/python-jdcal/python-jdcal.spec
+++ b/packages/python-jdcal/python-jdcal.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.4.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Julian dates from proleptic Gregorian and Julian calendars
 
 License:        BSD
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.4.1-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.4.1-4
 - Build against python 3.11
 

--- a/packages/python-jeepney/python-jeepney.spec
+++ b/packages/python-jeepney/python-jeepney.spec
@@ -4,7 +4,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.8.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        This is the extensible, standards compliant build backend used by Hatch.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -25,6 +25,9 @@ BuildRequires:  pyproject-rpm-macros
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
@@ -50,6 +53,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.8.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.8.0-2
 - Build against python 3.11
 

--- a/packages/python-jinja2/python-jinja2.spec
+++ b/packages/python-jinja2/python-jinja2.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        3.1.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A very fast and expressive template engine
 
 License:        BSD-3-Clause
@@ -30,6 +30,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-markupsafe >= 2.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -67,6 +71,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.1.2-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.1.2-2
 - Build against python 3.11
 

--- a/packages/python-jmespath/python-jmespath.spec
+++ b/packages/python-jmespath/python-jmespath.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.10.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        JSON Matching Expressions
 
 License:        MIT
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.10.0-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.10.0-4
 - Build against python 3.11
 

--- a/packages/python-jq/python-jq.spec
+++ b/packages/python-jq/python-jq.spec
@@ -11,7 +11,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.6.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        jq is a lightweight and flexible JSON processor
 
 License:        BSD 2-Clause
@@ -29,6 +29,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -66,5 +69,8 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.6.0-2
+- Add python39 obsoletes to package
+
 * Mon Nov 13 2023 Odilon Sousa <osousa@redhat.com> - 1.6.0-1
 - Initial package.

--- a/packages/python-json-stream-rs-tokenizer/python-json-stream-rs-tokenizer.spec
+++ b/packages/python-json-stream-rs-tokenizer/python-json-stream-rs-tokenizer.spec
@@ -11,7 +11,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.4.25
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Faster tokenizer for the json-stream Python library
 
 License:        MIT
@@ -29,6 +29,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools-rust
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pkg_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pkg_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pkg_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pkg_name}
@@ -60,5 +63,8 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.4.25-2
+- Add python39 obsoletes to package
+
 * Mon Nov 13 2023 Odilon Sousa <osousa@redhat.com> - 0.4.25-1
 - Initial package.

--- a/packages/python-json-stream/python-json-stream.spec
+++ b/packages/python-json-stream/python-json-stream.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        2.3.2
-Release:        1
+Release:        2
 Summary:        Streaming JSON encoder and decoder
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -30,6 +30,9 @@ BuildRequires:  pyproject-rpm-macros
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pkg_name}}
 Requires:       python%{python3_pkgversion}-json_stream_rs_tokenizer >= 0.4.17
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n python%{python3_pkgversion}-%{pkg_name}
 %{summary}
@@ -54,5 +57,8 @@ set -ex
 %{python3_sitelib}/%{pkg_name}/
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.3.2-2
+- Add python39 obsoletes to package
+
 * Mon Nov 13 2023 Odilon Sousa <osousa@redhat.com> - 2.3.2-1
 - Initial package.

--- a/packages/python-jsonschema/python-jsonschema.spec
+++ b/packages/python-jsonschema/python-jsonschema.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        4.10.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        An implementation of JSON Schema validation for Python
 
 License:        MIT
@@ -36,6 +36,10 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-attrs >= 17.4.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-pyrsistent >= 0.14.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six >= 1.11.0
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -76,6 +80,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 4.10.3-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 4.10.3-2
 - Build against python 3.11
 

--- a/packages/python-keyring/python-keyring.spec
+++ b/packages/python-keyring/python-keyring.spec
@@ -4,7 +4,7 @@
 
 Name:           python-%{pypi_name}
 Version:        24.2.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Store and access your passwords safely.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -32,6 +32,9 @@ Requires:       python%{python3_pkgversion}-importlib-metadata
 Requires:       python%{python3_pkgversion}-jaraco.classes
 Requires:       python%{python3_pkgversion}-SecretStorage
 Requires:       python%{python3_pkgversion}-jeepney
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -60,6 +63,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 24.2.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 24.2.0-2
 - Build against python 3.11
 

--- a/packages/python-ldap/python-ldap.spec
+++ b/packages/python-ldap/python-ldap.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        3.4.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Python modules for implementing LDAP clients
 
 License:        Python style
@@ -37,6 +37,10 @@ Requires:       openldap
 Obsoletes: python3-pyldap < 3
 Provides:  python3-pyldap = %{version}-%{release}
 Provides:  python3-pyldap%{?_isa} = %{version}-%{release}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 %{summary}
@@ -76,6 +80,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.4.2-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.4.2-2
 - Build against python 3.11
 

--- a/packages/python-lockfile/python-lockfile.spec
+++ b/packages/python-lockfile/python-lockfile.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.12.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Platform-independent file locking module
 
 License:        None
@@ -28,6 +28,9 @@ BuildRequires:  python%{python3_pkgversion}-setuptools
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.12.2-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.12.2-2
 - Build against python 3.11
 

--- a/packages/python-lxml/python-lxml.spec
+++ b/packages/python-lxml/python-lxml.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        4.9.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API
 
 License:        BSD-3-Clause
@@ -28,6 +28,10 @@ BuildRequires:  libxslt-devel
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -66,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 4.9.2-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 4.9.2-2
 - Build against python 3.11
 


### PR DESCRIPTION
(cherry picked from commit e31d216b1eab5f3a0be4e714189368649be6d7a0)