### PR TITLE
Python 3.9 obsoletes a through d

### DIFF
--- a/packages/python-aiodns/python-aiodns.spec
+++ b/packages/python-aiodns/python-aiodns.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.0.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Simple DNS resolver for asyncio
 
 License:        MIT
@@ -28,6 +28,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-pycares >= 4.0.0
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.0.0-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.0.0-4
 - Build against python 3.11
 

--- a/packages/python-aiofiles/python-aiofiles.spec
+++ b/packages/python-aiofiles/python-aiofiles.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        22.1.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        File support for asyncio
 
 License:        Apache 2.0
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 22.1.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 22.1.0-2
 - Build against python 3.11
 

--- a/packages/python-aiohttp-socks/python-aiohttp-socks.spec
+++ b/packages/python-aiohttp-socks/python-aiohttp-socks.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.7.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Proxy connector for aiohttp
 
 License:        Apache 2
@@ -32,6 +32,10 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-aiohttp >= 2.3.2
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-attrs >= 19.2.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-socks < 3.0.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-socks >= 2.0.0
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -69,6 +73,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.7.1-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.7.1-4
 - Build against python 3.11
 

--- a/packages/python-aiohttp-xmlrpc/python-aiohttp-xmlrpc.spec
+++ b/packages/python-aiohttp-xmlrpc/python-aiohttp-xmlrpc.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.5.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        aiohttp XML-RPC server handler and client
 
 License:        MIT
@@ -29,6 +29,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-aiohttp
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-lxml
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.5.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.5.0-3
 - Build against python 3.11
 

--- a/packages/python-aiohttp/python-aiohttp.spec
+++ b/packages/python-aiohttp/python-aiohttp.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.8.3
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Async http client/server framework (asyncio)
 
 License:        Apache 2
@@ -45,6 +45,10 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-yarl >= 1.0
 
 # aiohttp depends on stdlib's mimetypes which reads /etc/mime.types
 Requires:       /etc/mime.types
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -81,6 +85,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.8.3-5
+- Add python39 obsoletes to package
+
 * Mon Nov 13 2023 Odilon Sousa <osousa@redhat.com> - 3.8.3-4
 - Remove cchardet since it's only request for Python < 3.10
 

--- a/packages/python-aioredis/python-aioredis.spec
+++ b/packages/python-aioredis/python-aioredis.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.0.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        asyncio (PEP 3156) Redis support
 
 License:        MIT
@@ -30,6 +30,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-async-timeout
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-typing-extensions
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -67,6 +71,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.0.1-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.0.1-3
 - Build against python 3.11
 

--- a/packages/python-aiosignal/python-aiosignal.spec
+++ b/packages/python-aiosignal/python-aiosignal.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.3.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        aiosignal: a list of registered asynchronous callbacks
 
 License:        Apache 2.0
@@ -29,6 +29,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-frozenlist >= 1.1.0
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -66,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.3.1-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.3.1-2
 - Build against python 3.11
 

--- a/packages/python-anyio/python-anyio.spec
+++ b/packages/python-anyio/python-anyio.spec
@@ -4,7 +4,7 @@
 
 Name:           python-%{pypi_name}
 Version:        3.6.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        High level compatibility layer for multiple asynchronous event loop implementations
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -30,6 +30,9 @@ Summary:        %{summary}
 Requires:       python%{python3_pkgversion}-exceptiongroup
 Requires:       python%{python3_pkgversion}-idna
 Requires:       python%{python3_pkgversion}-sniffio
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -57,6 +60,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.6.2-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.6.2-2
 - Build against python 3.11
 

--- a/packages/python-asgiref/python-asgiref.spec
+++ b/packages/python-asgiref/python-asgiref.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.6.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        ASGI specs, helper code, and adapters
 
 License:        BSD
@@ -26,6 +26,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -62,6 +66,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.6.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.6.0-2
 - Build against python 3.11
 

--- a/packages/python-async-lru/python-async-lru.spec
+++ b/packages/python-async-lru/python-async-lru.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.0.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Simple lru_cache for asyncio
 
 License:        MIT
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.0.3-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.0.3-2
 - Build against python 3.11
 

--- a/packages/python-async-timeout/python-async-timeout.spec
+++ b/packages/python-async-timeout/python-async-timeout.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        4.0.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Timeout context manager for asyncio programs
 
 License:        Apache 2
@@ -28,6 +28,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-typing-extensions >= 3.6.5
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 4.0.2-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 4.0.2-3
 - Build against python 3.11
 

--- a/packages/python-asyncio-throttle/python-asyncio-throttle.spec
+++ b/packages/python-asyncio-throttle/python-asyncio-throttle.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.0.2
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Simple, easy-to-use throttler for asyncio
 
 License:        MIT
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.0.2-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.0.2-4
 - Build against python 3.11
 

--- a/packages/python-attrs/python-attrs.spec
+++ b/packages/python-attrs/python-attrs.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        21.4.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Classes Without Boilerplate
 
 License:        MIT
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 21.4.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 21.4.0-3
 - Build against python 3.11
 

--- a/packages/python-azure-common/python-azure-common.spec
+++ b/packages/python-azure-common/python-azure-common.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.1.27
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Microsoft Azure Client Library for Python (Common)
 
 License:        MIT License
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -63,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.1.27-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.1.27-4
 - Build against python 3.11
 

--- a/packages/python-azure-core/python-azure-core.spec
+++ b/packages/python-azure-core/python-azure-core.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.19.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Microsoft Azure Core Library for Python
 
 License:        MIT License
@@ -29,6 +29,10 @@ Summary:        %{summary}
 
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-requests >= 2.18.4
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six >= 1.11
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.19.1-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.19.1-3
 - Build against python 3.11
 

--- a/packages/python-azure-storage-blob/python-azure-storage-blob.spec
+++ b/packages/python-azure-storage-blob/python-azure-storage-blob.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        12.9.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Microsoft Azure Blob Storage Client Library for Python
 
 License:        MIT License
@@ -32,6 +32,10 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-azure-core < 2
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-azure-core >= 1.10
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-cryptography >= 2.1.4
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-msrest >= 0.6.21
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -68,6 +72,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 12.9.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 12.9.0-3
 - Build against python 3.11
 

--- a/packages/python-azure-storage-common/python-azure-storage-common.spec
+++ b/packages/python-azure-storage-common/python-azure-storage-common.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.1.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Microsoft Azure Storage Common Client Library for Python
 
 License:        MIT License
@@ -31,6 +31,10 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-azure-common >= 1.1.5
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-cryptography
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-dateutil
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-requests
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -68,6 +72,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.1.0-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.1.0-4
 - Build against python 3.11
 

--- a/packages/python-backoff/python-backoff.spec
+++ b/packages/python-backoff/python-backoff.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.2.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Function decoration for backoff and retry
 
 License:        MIT
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -62,6 +66,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.2.1-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.2.1-2
 - Build against python 3.11
 

--- a/packages/python-beautifulsoup4/python-beautifulsoup4.spec
+++ b/packages/python-beautifulsoup4/python-beautifulsoup4.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        4.11.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Screen-scraping library
 
 License:        MIT
@@ -28,6 +28,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-soupsieve > 1.2
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -67,6 +71,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 4.11.2-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 4.11.2-2
 - Build against python 3.11
 

--- a/packages/python-bindep/python-bindep.spec
+++ b/packages/python-bindep/python-bindep.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.11.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Binary dependency utility
 
 License:        Apache License, Version 2.0
@@ -32,6 +32,10 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-distro >= 1.7.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-packaging
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-pbr >= 2.0.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -70,6 +74,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.11.0-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.11.0-3
 - Build against python 3.11
 

--- a/packages/python-bleach-allowlist/python-bleach-allowlist.spec
+++ b/packages/python-bleach-allowlist/python-bleach-allowlist.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.0.3
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Curated lists of tags and attributes for sanitizing html
 
 License:        BSD License
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -63,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.0.3-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.0.3-4
 - Build against python 3.11
 

--- a/packages/python-bleach-whitelist/python-bleach-whitelist.spec
+++ b/packages/python-bleach-whitelist/python-bleach-whitelist.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.0.11
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Curated lists of tags and attributes for sanitizing html
 
 License:        BSD License
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -63,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.0.11-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.0.11-4
 - Build against python 3.11
 

--- a/packages/python-bleach/python-bleach.spec
+++ b/packages/python-bleach/python-bleach.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.3.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        An easy safelist-based HTML-sanitizing tool
 
 License:        Apache Software License
@@ -29,6 +29,10 @@ Summary:        %{summary}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-packaging
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six >= 1.9.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-webencodings
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -66,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.3.1-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.3.1-3
 - Build against python 3.11
 

--- a/packages/python-boto3/python-boto3.spec
+++ b/packages/python-boto3/python-boto3.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.18.35
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        The AWS SDK for Python
 
 License:        Apache License 2.0
@@ -35,6 +35,10 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-jmespath < 1.0.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-jmespath >= 0.7.1
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-s3transfer < 0.6.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-s3transfer >= 0.5.0
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -72,6 +76,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.18.35-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.18.35-4
 - Build against python 3.11
 

--- a/packages/python-botocore/python-botocore.spec
+++ b/packages/python-botocore/python-botocore.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.21.35
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Low-level, data-driven core of boto 3
 
 License:        Apache License 2.0
@@ -38,6 +38,9 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-jmespath < 1.0.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-jmespath >= 0.7.1
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-urllib3 < 1.27
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-urllib3 >= 1.25.4
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -75,6 +78,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.21.35-7
+- Add python39 obsoletes to package
+
 * Wed Nov 15 2023 Patrick Creech <pcreech@redhat.com> - 1.21.35-6
 - Don't use epoch for dateutil dependency if we aren't using system python
 

--- a/packages/python-box/python-box.spec
+++ b/packages/python-box/python-box.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        5.1.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Advanced Python dictionaries with dot notation access
 
 License:        MIT
@@ -30,6 +30,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-ruamel-yaml
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-toml
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -67,6 +71,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 5.1.0-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 5.1.0-4
 - Build against python 3.11
 

--- a/packages/python-bracex/python-bracex.spec
+++ b/packages/python-bracex/python-bracex.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.2.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Bash style brace expander
 
 License:        MIT License
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.2.1-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.2.1-3
 - Build against python 3.11
 

--- a/packages/python-brotli/python-brotli.spec
+++ b/packages/python-brotli/python-brotli.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        1.0.9
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Python bindings for the Brotli compression library
 
 License:        MIT
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -66,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.0.9-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.0.9-3
 - Build against python 3.11
 

--- a/packages/python-build/python-build.spec
+++ b/packages/python-build/python-build.spec
@@ -4,7 +4,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.10.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A simple, correct Python build frontend
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -27,6 +27,9 @@ Requires:       python%{python3_pkgversion}-packaging >= 19.0
 Requires:       python%{python3_pkgversion}-pyproject_hooks
 Requires:       python%{python3_pkgversion}-importlib-metadata >= 4.6
 Requires:       python%{python3_pkgversion}-tomli >= 1.1.0
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -53,6 +56,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.10.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.10.0-2
 - Build against python 3.11
 

--- a/packages/python-cachecontrol/python-cachecontrol.spec
+++ b/packages/python-cachecontrol/python-cachecontrol.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        0.12.14
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        httplib2 caching for requests
 
 License:        None
@@ -32,6 +32,9 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-lockfile >= 0.9
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-msgpack >= 0.5.2
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-requests
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-filelock >= 3.8.0
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -70,6 +73,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.12.14-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.12.14-2
 - Build against python 3.11
 

--- a/packages/python-calver/python-calver.spec
+++ b/packages/python-calver/python-calver.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2022.06.26
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Setuptools extension for CalVer package versions
 
 License:        None
@@ -29,6 +29,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -66,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2022.06.26-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2022.06.26-2
 - Build against python 3.11
 

--- a/packages/python-certifi/python-certifi.spec
+++ b/packages/python-certifi/python-certifi.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2022.12.7
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Python package for providing Mozilla's CA Bundle
 
 License:        MPL-2.0
@@ -29,6 +29,10 @@ BuildRequires:  ca-certificates
 Summary:        %{summary}
 Requires:       ca-certificates
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -68,6 +72,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2022.12.7-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2022.12.7-2
 - Build against python 3.11
 

--- a/packages/python-cffi/python-cffi.spec
+++ b/packages/python-cffi/python-cffi.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.15.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Foreign Function Interface for Python calling C code
 
 License:        MIT
@@ -30,6 +30,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-pycparser
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -68,6 +72,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.15.1-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.15.1-2
 - Build against python 3.11
 

--- a/packages/python-charset-normalizer/python-charset-normalizer.spec
+++ b/packages/python-charset-normalizer/python-charset-normalizer.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.1.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet
 
 License:        MIT
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.1.1-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.1.1-2
 - Build against python 3.11
 

--- a/packages/python-cleo/python-cleo.spec
+++ b/packages/python-cleo/python-cleo.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pypi_name}
 Version:        2.0.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Cleo allows you to create beautiful and testable command-line interfaces.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -28,6 +28,9 @@ Summary:        %{summary}
 
 Requires:  %{?scl_prefix}python%{python3_pkgversion}-crashtest >= 0.4.1 
 Requires:  %{?scl_prefix}python%{python3_pkgversion}-rapidfuzz >= 2.2.0
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -52,6 +55,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.0.1-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.0.1-2
 - Build against python 3.11
 

--- a/packages/python-click-shell/python-click-shell.spec
+++ b/packages/python-click-shell/python-click-shell.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        An extension to click that easily turns your click app into a shell utility
 
 License:        BSD
@@ -28,6 +28,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-click >= 6
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.1-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.1-4
 - Build against python 3.11
 

--- a/packages/python-click/python-click.spec
+++ b/packages/python-click/python-click.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        8.1.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Composable command line interface toolkit
 
 License:        BSD-3-Clause
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -63,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 8.1.3-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 8.1.3-2
 - Build against python 3.11
 

--- a/packages/python-colorama/python-colorama.spec
+++ b/packages/python-colorama/python-colorama.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.4.4
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Cross-platform colored terminal text
 
 License:        BSD
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -66,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.4.4-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.4.4-4
 - Build against python 3.11
 

--- a/packages/python-commonmark/python-commonmark.spec
+++ b/packages/python-commonmark/python-commonmark.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.9.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Python parser for the CommonMark Markdown spec
 
 License:        BSD-3-Clause
@@ -29,6 +29,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-future >= 0.14.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -67,6 +71,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.9.1-7
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.9.1-6
 - Build against python 3.11
 

--- a/packages/python-contextlib2/python-contextlib2.spec
+++ b/packages/python-contextlib2/python-contextlib2.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        21.6.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Backports and enhancements for the contextlib module
 
 License:        PSF License
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 21.6.0-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 21.6.0-4
 - Build against python 3.11
 

--- a/packages/python-coreapi/python-coreapi.spec
+++ b/packages/python-coreapi/python-coreapi.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.3.3
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Python client library for Core API
 
 License:        BSD
@@ -32,6 +32,10 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-itypes
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-requests
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-uritemplate
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -69,6 +73,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.3.3-6
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.3.3-5
 - Build against python 3.11
 

--- a/packages/python-coreschema/python-coreschema.spec
+++ b/packages/python-coreschema/python-coreschema.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.0.4
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Core Schema
 
 License:        BSD
@@ -28,6 +28,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-jinja2
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.0.4-6
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.0.4-5
 - Build against python 3.11
 

--- a/packages/python-crashtest/python-crashtest.spec
+++ b/packages/python-crashtest/python-crashtest.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.4.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Manage Python errors with ease
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -25,6 +25,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-poetry_core
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
@@ -50,6 +53,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.4.1-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.4.1-2
 - Build against python 3.11
 

--- a/packages/python-cryptography/python-cryptography.spec
+++ b/packages/python-cryptography/python-cryptography.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        38.0.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        cryptography is a package which provides cryptographic recipes and primitives to Python developers
 
 License:        BSD or Apache License, Version 2.0
@@ -35,6 +35,10 @@ BuildRequires:  gcc
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-cffi >= 1.12
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -73,6 +77,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 38.0.4-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 38.0.4-2
 - Build against python 3.11
 

--- a/packages/python-dataclasses/python-dataclasses.spec
+++ b/packages/python-dataclasses/python-dataclasses.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.8
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        A backport of the dataclasses module for Python 3.6
 
 License:        Apache
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.8-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.8-4
 - Build against python 3.11
 

--- a/packages/python-dateutil/python-dateutil.spec
+++ b/packages/python-dateutil/python-dateutil.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        2.8.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Extensions to the standard Python datetime module
 
 License:        Dual License
@@ -33,6 +33,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six >= 1.5
 Obsoletes:      %{?scl_prefix}python36-dateutil
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -70,6 +74,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.8.2-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.8.2-3
 - Build against python 3.11
 

--- a/packages/python-debian/python-debian.spec
+++ b/packages/python-debian/python-debian.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        0.1.44
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Debian package related modules
 
 License:        GPL-2+
@@ -30,6 +30,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-chardet
 Requires:       zstd
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
@@ -69,6 +73,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.1.44-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.1.44-4
 - Build against python 3.11
 

--- a/packages/python-defusedxml/python-defusedxml.spec
+++ b/packages/python-defusedxml/python-defusedxml.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.7.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        XML bomb protection for Python stdlib modules
 
 License:        PSFL
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.7.1-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.7.1-4
 - Build against python 3.11
 

--- a/packages/python-deprecated/python-deprecated.spec
+++ b/packages/python-deprecated/python-deprecated.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        1.2.13
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Python @deprecated decorator to deprecate old python classes, functions or methods
 
 License:        MIT
@@ -30,6 +30,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-wrapt >= 1.10
 Conflicts:      %{?scl_prefix}python%{python3_pkgversion}-wrapt >= 2
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
+%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 %{summary}
@@ -66,6 +70,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.2.13-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.2.13-2
 - Build against python 3.11
 

--- a/packages/python-diff-match-patch/python-diff-match-patch.spec
+++ b/packages/python-diff-match-patch/python-diff-match-patch.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        20200713
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Repackaging of Google's Diff Match and Patch libraries
 
 License:        Apache
@@ -28,6 +28,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools >= 38.6.0
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -65,6 +69,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 20200713-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 20200713-4
 - Build against python 3.11
 

--- a/packages/python-distlib/python-distlib.spec
+++ b/packages/python-distlib/python-distlib.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.3.6
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Distlib is a library which implements low-level functions that relate to packaging and distribution of Python software.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -25,6 +25,9 @@ BuildRequires:  python%{python3_pkgversion}-setuptools-scm
 %package -n     python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -54,6 +57,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.3.6-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.3.6-2
 - Build against python 3.11
 

--- a/packages/python-distro/python-distro.spec
+++ b/packages/python-distro/python-distro.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        %{pypi_version}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Distro - an OS platform information API
 
 License:        Apache License, Version 2.0
@@ -30,6 +30,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-setuptools
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -69,6 +73,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.7.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.7.0-2
 - Build against python 3.11
 

--- a/packages/python-django-auth-ldap/python-django-auth-ldap.spec
+++ b/packages/python-django-auth-ldap/python-django-auth-ldap.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        4.0.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Django LDAP authentication backend
 
 License:        BSD
@@ -30,6 +30,10 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-django >= 2.2
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-ldap >= 3.1
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -69,6 +73,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 4.0.0-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 4.0.0-2
 - Build against python 3.11
 

--- a/packages/python-django-cleanup/python-django-cleanup.spec
+++ b/packages/python-django-cleanup/python-django-cleanup.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        5.1.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Deletes old files
 
 License:        MIT License
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 5.1.0-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 5.1.0-4
 - Build against python 3.11
 

--- a/packages/python-django-ipware/python-django-ipware.spec
+++ b/packages/python-django-ipware/python-django-ipware.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.0.7
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A Django application to retrieve user's IP address
 
 License:        MIT
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -64,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.0.7-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 3.0.7-3
 - Build against python 3.11
 

--- a/packages/python-django-prometheus/python-django-prometheus.spec
+++ b/packages/python-django-prometheus/python-django-prometheus.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.1.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Django middlewares to monitor your application with Prometheus
 
 License:        Apache
@@ -28,6 +28,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-prometheus-client >= 0.7
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -67,6 +71,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.1.0-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 2.1.0-4
 - Build against python 3.11
 

--- a/packages/python-django-storages/python-django-storages.spec
+++ b/packages/python-django-storages/python-django-storages.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.12.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Support for many storage backends in Django
 
 License:        BSD-3-Clause
@@ -30,6 +30,10 @@ Summary:        %{summary}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-django >= 2.2
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-azure-storage-blob >= 12.0.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-boto3 >= 1.4.4
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -67,6 +71,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.12.3-4
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.12.3-3
 - Build against python 3.11
 

--- a/packages/python-django/python-django.spec
+++ b/packages/python-django/python-django.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        4.2.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A high-level Python web framework that encourages rapid development and clean, pragmatic design
 
 License:        BSD-3-Clause
@@ -37,6 +37,7 @@ Obsoletes:      python3-%{srcname} < %{version}-%{release}
 %endif
 %if 0%{?rhel} == 8
 Obsoletes:      python38-%{srcname} < %{version}-%{release}
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
 %endif
 
 
@@ -83,6 +84,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 4.2.2-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 4.2.2-2
 - Build against python 3.11
 

--- a/packages/python-djangorestframework-queryfields/python-djangorestframework-queryfields.spec
+++ b/packages/python-djangorestframework-queryfields/python-djangorestframework-queryfields.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.0.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Serialize a partial subset of fields in the API
 
 License:        MIT
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -63,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.0.0-7
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.0.0-6
 - Build against python 3.11
 

--- a/packages/python-docutils/python-docutils.spec
+++ b/packages/python-docutils/python-docutils.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.20.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Docutils -- Python Documentation Utilities
 
 License:        Public Domain and BSD and Python and GPLv3+
@@ -27,6 +27,9 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -82,6 +85,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.20.1-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.20.1-2
 - Build against python 3.11
 

--- a/packages/python-dotenv/python-dotenv.spec
+++ b/packages/python-dotenv/python-dotenv.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        0.14.0
-Release:        9%{?dist}
+Release:        10%{?dist}
 Summary:        Add .env support to your django/flask apps in development and deployments
 
 License:        BSD-3-Clause
@@ -34,6 +34,7 @@ Obsoletes:      python3-%{srcname} < %{version}-%{release}
 %endif
 %if 0%{?rhel} == 8
 Obsoletes:      python38-%{srcname} < %{version}-%{release}
+Obsoletes:      python39-%{srcname} < %{version}-%{release}
 %endif
 
 
@@ -73,6 +74,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.14.0-10
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.14.0-9
 - Build against python 3.11
 

--- a/packages/python-drf-yasg/python-drf-yasg.spec
+++ b/packages/python-drf-yasg/python-drf-yasg.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.17.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Automated generation of real Swagger/OpenAPI 2.0 schemas from Django Rest Framework code
 
 License:        BSD License
@@ -37,6 +37,10 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-packaging
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-ruamel-yaml >= 0.15.34
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six >= 1.10.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-uritemplate >= 3.0.0
+
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -74,6 +78,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.17.1-5
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 1.17.1-4
 - Build against python 3.11
 

--- a/packages/python-dulwich/python-dulwich.spec
+++ b/packages/python-dulwich/python-dulwich.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.21.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Python Git Library
 
 License:        Apachev2 or later or GPLv2
@@ -26,6 +26,9 @@ BuildRequires:  python%{python3_pkgversion}-pip
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       python%{python3_pkgversion}-urllib3 >= 1.24.1
+%if 0%{?rhel} == 8
+Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
+%endif
 
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
@@ -59,6 +62,9 @@ set -ex
 
 
 %changelog
+* Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.21.3-3
+- Add python39 obsoletes to package
+
 * Sat Nov 11 2023 Odilon Sousa <osousa@redhat.com> - 0.21.3-2
 - Build against python 3.11
 


### PR DESCRIPTION
(cherry picked from commit c6823a31727f5e33e4988d99b5582e24d9815428)