### PR TITLE
Obsolete more python packages

### DIFF
--- a/packages/pulpcore-obsolete-packages/pulpcore-obsolete-packages.spec
+++ b/packages/pulpcore-obsolete-packages/pulpcore-obsolete-packages.spec
@@ -1,6 +1,6 @@
 Name: pulpcore-obsolete-packages
 Version: 1.0
-Release: 4%{?dist}
+Release: 5%{?dist}
 License: MIT
 Summary: A package to obsolete retired packages
 URL: https://github.com/theforeman/pulpcore-packaging
@@ -10,6 +10,8 @@ Obsoletes:      python3-django-currentuser < 0.5.3-6
 %if 0%{?rhel} == 8
 Obsoletes:      python39-django-currentuser < 0.5.3-6
 Obsoletes:      python39-pyyaml < 5.4.1-5
+Obsoletes:      python39-importlib-resources < 5.4.0-6
+Obsoletes:      python39-django-guardian < 2.4.0-7
 %endif
 
 %description
@@ -25,6 +27,9 @@ from the distribution for some reason.
 %files
 
 %changelog
+* Fri Dec 08 2023 Patrick Creech <pcreech@redhat.com> - 1.0-5
+- Add django-guardian and importlib-resources to obsoletes
+
 * Wed Nov 22 2023 Patrick Creech <pcreech@redhat.com> - 1.0-4
 - Don't obsolete python3-pyyaml
 


### PR DESCRIPTION
Obsolete python39-django-guardian and python39-importlib-resources