### PR TITLE
Cherry pick repoclosure fixes from rpm/develop to rpm/3.22

### DIFF
--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -11,6 +11,7 @@ assumeyes=1
 syslog_ident=repoclosure
 syslog_device=
 protected_packages=
+installroot=/
 
 [el9-baseos]
 name=CentOS Stream 9 - BaseOS

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -16,17 +16,17 @@ module_platform_id=platform:el8
 
 
 [el9-baseos]
-name=CentOS Stream $releasever - BaseOS
+name=CentOS Stream 9 - BaseOS
 metalink=https://mirrors.centos.org/metalink?repo=centos-baseos-9-stream&arch=x86_64&protocol=https,http
 enabled=1
 
 [el9-appstream]
-name=CentOS Stream $releasever - AppStream
+name=CentOS Stream 9 - AppStream
 metalink=https://mirrors.centos.org/metalink?repo=centos-appstream-9-stream&arch=x86_64&protocol=https,http
 enabled=1
 
 [el9-crb]
-name=CentOS Stream $releasever - CRB
+name=CentOS Stream 9 - CRB
 metalink=https://mirrors.centos.org/metalink?repo=centos-crb-9-stream&arch=x86_64&protocol=https,http
 enabled=1
 

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -10,10 +10,7 @@ gpgcheck=0
 assumeyes=1
 syslog_ident=repoclosure
 syslog_device=
-mdpolicy=group:primary
 protected_packages=
-module_platform_id=platform:el8
-
 
 [el9-baseos]
 name=CentOS Stream 9 - BaseOS


### PR DESCRIPTION
To fix failures like https://community.theforeman.org/t/pulpcore-3-28-rpm-pipeline-204-failed/36238/2

Similar to https://github.com/theforeman/pulpcore-packaging/pull/830, but for 3.22.