### PR TITLE
Remove overzealous obsoletes from packages

### DIFF
--- a/packages/python-multidict/python-multidict.spec
+++ b/packages/python-multidict/python-multidict.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        6.0.4
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        multidict implementation
 
 License:        Apache 2
@@ -27,9 +27,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -66,6 +63,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 6.0.4-4
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 6.0.4-3
 - Add python39 obsoletes to package
 

--- a/packages/python-naya/python-naya.spec
+++ b/packages/python-naya/python-naya.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.1.1
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        A fast streaming JSON parser written in pure python
 
 License:        MIT
@@ -32,9 +32,6 @@ Obsoletes:      python38-%{pypi_name} < %{version}-%{release}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -70,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 1.1.1-6
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.1.1-5
 - Add python39 obsoletes to package
 

--- a/packages/python-oauthlib/python-oauthlib.spec
+++ b/packages/python-oauthlib/python-oauthlib.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.1.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        A generic, spec-compliant, thorough implementation of the OAuth request-signing logic
 
 License:        BSD
@@ -28,9 +28,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -67,6 +64,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 3.1.1-5
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.1.1-4
 - Add python39 obsoletes to package
 

--- a/packages/python-openpyxl/python-openpyxl.spec
+++ b/packages/python-openpyxl/python-openpyxl.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.1.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A Python library to read/write Excel 2010 xlsx/xlsm files
 
 License:        MIT
@@ -29,9 +29,6 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-et-xmlfile
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -67,6 +64,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 3.1.0-4
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.1.0-3
 - Add python39 obsoletes to package
 

--- a/packages/python-packaging/python-packaging.spec
+++ b/packages/python-packaging/python-packaging.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        21.3
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Core utilities for Python packages
 
 License:        BSD-2-Clause or Apache-2.0
@@ -30,9 +30,6 @@ Summary:        %{summary}
 Conflicts:      %{?scl_prefix}python%{python3_pkgversion}-pyparsing = 3.0.5
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-pyparsing >= 2.0.2
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -69,6 +66,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 21.3-5
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 21.3-4
 - Add python39 obsoletes to package
 

--- a/packages/python-parsley/python-parsley.spec
+++ b/packages/python-parsley/python-parsley.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        1.3
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Parsing and pattern matching made easy
 
 License:        MIT License
@@ -30,9 +30,6 @@ Summary:        %{summary}
 Provides:       %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name} = %{version}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{srcname} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 %{summary}
@@ -70,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 1.3-5
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.3-4
 - Add python39 obsoletes to package
 

--- a/packages/python-productmd/python-productmd.spec
+++ b/packages/python-productmd/python-productmd.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.33
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Product, compose and installation media metadata library
 
 License:        LGPLv2.1
@@ -28,9 +28,6 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -67,6 +64,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 1.33-6
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.33-5
 - Add python39 obsoletes to package
 

--- a/packages/python-prometheus-client/python-prometheus-client.spec
+++ b/packages/python-prometheus-client/python-prometheus-client.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.8.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Python client for the Prometheus monitoring system
 
 License:        Apache Software License 2.0
@@ -28,9 +28,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -66,6 +63,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 0.8.0-6
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.8.0-5
 - Add python39 obsoletes to package
 

--- a/packages/python-protobuf/python-protobuf.spec
+++ b/packages/python-protobuf/python-protobuf.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        4.21.6
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Protocol Buffers
 
 License:        BSD-3-Clause
@@ -27,9 +27,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
@@ -68,6 +65,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 4.21.6-4
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 4.21.6-3
 - Add python39 obsoletes to package
 

--- a/packages/python-psycopg2/python-psycopg2.spec
+++ b/packages/python-psycopg2/python-psycopg2.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.9.3
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        psycopg2 - Python-PostgreSQL Database Adapter
 
 License:        LGPL with exceptions
@@ -28,9 +28,6 @@ BuildRequires:  postgresql-devel
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -67,6 +64,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 2.9.3-5
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.9.3-4
 - Add python39 obsoletes to package
 

--- a/packages/python-pyOpenSSL/python-pyOpenSSL.spec
+++ b/packages/python-pyOpenSSL/python-pyOpenSSL.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        22.1.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Python wrapper module around the OpenSSL library
 
 License:        Apache License, Version 2.0
@@ -30,9 +30,6 @@ Summary:        %{summary}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-cryptography >= 38.0.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-six >= 1.5.2
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -69,6 +66,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 22.1.0-4
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 22.1.0-3
 - Add python39 obsoletes to package
 

--- a/packages/python-pyasn1-modules/python-pyasn1-modules.spec
+++ b/packages/python-pyasn1-modules/python-pyasn1-modules.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.2.8
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A collection of ASN.1-based protocols modules
 
 License:        BSD-2-Clause
@@ -30,9 +30,7 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-pyasn1 >= 0.4.6
 Conflicts:       %{?scl_prefix}python%{python3_pkgversion}-pyasn1 > 0.6
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -69,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 0.2.8-4
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.2.8-3
 - Add python39 obsoletes to package
 

--- a/packages/python-pyasn1/python-pyasn1.spec
+++ b/packages/python-pyasn1/python-pyasn1.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.4.8
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        ASN.1 types and codecs
 
 License:        BSD
@@ -28,9 +28,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -67,6 +64,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 0.4.8-4
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.4.8-3
 - Add python39 obsoletes to package
 

--- a/packages/python-pycairo/python-pycairo.spec
+++ b/packages/python-pycairo/python-pycairo.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.20.1
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Python interface for cairo
 
 License:        LGPL-2.1-only OR MPL-1.1
@@ -27,9 +27,7 @@ BuildRequires:  cairo-devel
 %package -n     %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
+
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -81,6 +79,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 1.20.1-6
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.20.1-5
 - Add python39 obsoletes to package
 

--- a/packages/python-pycares/python-pycares.spec
+++ b/packages/python-pycares/python-pycares.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        4.1.2
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Python interface for c-ares
 
 License:        MIT
@@ -30,9 +30,6 @@ Summary:        %{summary}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-cffi >= 1.5.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-idna >= 2.1
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -69,6 +66,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 4.1.2-5
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 4.1.2-4
 - Add python39 obsoletes to package
 

--- a/packages/python-pycparser/python-pycparser.spec
+++ b/packages/python-pycparser/python-pycparser.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.21
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        C parser in Python
 
 License:        BSD
@@ -29,9 +29,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -68,6 +65,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 2.21-5
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.21-4
 - Add python39 obsoletes to package
 

--- a/packages/python-pycryptodomex/python-pycryptodomex.spec
+++ b/packages/python-pycryptodomex/python-pycryptodomex.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.14.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Cryptographic library for Python
 
 License:        BSD, Public Domain
@@ -27,9 +27,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -66,6 +63,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 3.14.1-5
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.14.1-4
 - Add python39 obsoletes to package
 

--- a/packages/python-pygtrie/python-pygtrie.spec
+++ b/packages/python-pygtrie/python-pygtrie.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.5.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A pure Python trie data structure implementation
 
 License:        Apache-2.0
@@ -28,9 +28,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -65,6 +62,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 2.5.0-4
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.5.0-3
 - Add python39 obsoletes to package
 

--- a/packages/python-pymongo/python-pymongo.spec
+++ b/packages/python-pymongo/python-pymongo.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.11.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Python driver for MongoDB
 
 License:        Apache License, Version 2.0
@@ -27,9 +27,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -68,6 +65,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 3.11.0-6
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.11.0-5
 - Add python39 obsoletes to package
 

--- a/packages/python-pyparsing/python-pyparsing.spec
+++ b/packages/python-pyparsing/python-pyparsing.spec
@@ -10,7 +10,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.1.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Python parsing module
 
 License:        MIT License
@@ -30,9 +30,6 @@ BuildRequires:  pyproject-rpm-macros
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -57,6 +54,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 3.1.1-3
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.1.1-2
 - Add python39 obsoletes to package
 

--- a/packages/python-pypi-simple/python-pypi-simple.spec
+++ b/packages/python-pypi-simple/python-pypi-simple.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.9.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        PyPI Simple Repository API client library
 
 License:        MIT
@@ -30,9 +30,6 @@ Requires:  %{?scl_prefix}python%{python3_pkgversion}-packaging
 Requires:  %{?scl_prefix}python%{python3_pkgversion}-requests
 Requires:  %{?scl_prefix}python%{python3_pkgversion}-beautifulsoup4
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -71,6 +68,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 0.9.0-5
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.9.0-4
 - Add python39 obsoletes to package
 

--- a/packages/python-pyrsistent/python-pyrsistent.spec
+++ b/packages/python-pyrsistent/python-pyrsistent.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.18.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Persistent/Functional/Immutable data structures
 
 License:        MIT
@@ -27,9 +27,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -68,6 +65,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 0.18.1-5
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.18.1-4
 - Add python39 obsoletes to package
 

--- a/packages/python-python3-openid/python-python3-openid.spec
+++ b/packages/python-python3-openid/python-python3-openid.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        3.2.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        OpenID support for modern servers and consumers
 
 License:        None
@@ -29,9 +29,6 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-defusedxml
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -68,6 +65,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 3.2.0-5
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 3.2.0-4
 - Add python39 obsoletes to package
 

--- a/packages/python-pytz/python-pytz.spec
+++ b/packages/python-pytz/python-pytz.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2022.2.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        World timezone definitions, modern and historical
 
 License:        MIT
@@ -28,9 +28,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -67,6 +64,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 2022.2.1-5
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2022.2.1-4
 - Add python39 obsoletes to package
 

--- a/packages/python-pyyaml/python-pyyaml.spec
+++ b/packages/python-pyyaml/python-pyyaml.spec
@@ -10,7 +10,7 @@
 
 Name:           %{?scl_prefix}python-%{srcname}
 Version:        5.4.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        YAML parser and emitter for Python
 
 License:        MIT
@@ -36,9 +36,6 @@ Provides:       %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name} = %{versi
 %{?python_provide:%python_provide python%{python3_pkgversion}-yaml}
 Provides:       %{?scl_prefix}python%{python3_pkgversion}-yaml = %{version}-%{release}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{srcname} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{srcname}
 %{summary}
@@ -75,6 +72,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 5.4.1-7
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 5.4.1-6
 - Add python39 obsoletes to package
 

--- a/packages/python-redis/python-redis.spec
+++ b/packages/python-redis/python-redis.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        4.3.4
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Python client for Redis database and key-value store
 
 License:        MIT
@@ -30,9 +30,6 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-async-timeout >= 4.0.2
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-packaging >= 20.4
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-deprecated
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -69,6 +66,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 4.3.4-4
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 4.3.4-3
 - Add python39 obsoletes to package
 

--- a/packages/python-requests-oauthlib/python-requests-oauthlib.spec
+++ b/packages/python-requests-oauthlib/python-requests-oauthlib.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.3.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        OAuthlib authentication support for Requests
 
 License:        ISC
@@ -30,9 +30,6 @@ Summary:        %{summary}
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-oauthlib >= 3.0.0
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-requests >= 2.0.0
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -69,6 +66,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 1.3.0-5
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.3.0-4
 - Add python39 obsoletes to package
 

--- a/packages/python-requests/python-requests.spec
+++ b/packages/python-requests/python-requests.spec
@@ -9,7 +9,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        2.31.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Python HTTP for Humans
 
 License:        Apache 2.0
@@ -38,9 +38,6 @@ Requires:       %{?scl_prefix}python%{python3_pkgversion}-pyOpenSSL >= 0.14
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-urllib3 < 3
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-urllib3 >= 1.21.1
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -77,6 +74,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 2.31.0-4
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 2.31.0-3
 - Add python39 obsoletes to package
 

--- a/packages/python-requirements-parser/python-requirements-parser.spec
+++ b/packages/python-requirements-parser/python-requirements-parser.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        0.2.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Parses Pip requirement files
 
 License:        BSD
@@ -28,9 +28,6 @@ BuildRequires:  %{?scl_prefix}python%{python3_pkgversion}-setuptools
 Summary:        %{summary}
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -67,6 +64,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 0.2.0-6
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 0.2.0-5
 - Add python39 obsoletes to package
 

--- a/packages/python-rhsm/python-rhsm.spec
+++ b/packages/python-rhsm/python-rhsm.spec
@@ -8,7 +8,7 @@
 
 Name:           %{?scl_prefix}python-%{pypi_name}
 Version:        1.19.2
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        A Python library to communicate with a Red Hat Unified Entitlement Platform
 
 License:        GPLv2
@@ -30,9 +30,6 @@ Summary:        %{summary}
 
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-iniparse
 Requires:       %{?scl_prefix}python%{python3_pkgversion}-dateutil
-%if 0%{?rhel} == 8
-Obsoletes:      python39-%{pypi_name} < %{version}-%{release}
-%endif
 
 %description -n %{?scl_prefix}python%{python3_pkgversion}-%{pypi_name}
 %{summary}
@@ -68,6 +65,9 @@ set -ex
 
 
 %changelog
+* Tue Dec 12 2023 Patrick Creech <pcreech@redhat.com> - 1.19.2-6
+- Rollback overzealous obsoletes
+
 * Tue Nov 21 2023 Patrick Creech <pcreech@redhat.com> - 1.19.2-5
 - Add python39 obsoletes to package
 


### PR DESCRIPTION
python-miltidict through python-rhsm

(cherry picked from commit a4901b40cdf203f7bfa6e5df6c215025f373374a)