### PR TITLE
Obsolete older packages to ensure smooth upgrades

### DIFF
--- a/packages/pulpcore-obsolete-packages/pulpcore-obsolete-packages.spec
+++ b/packages/pulpcore-obsolete-packages/pulpcore-obsolete-packages.spec
@@ -1,6 +1,6 @@
 Name: pulpcore-obsolete-packages
 Version: 1.0
-Release: 6%{?dist}
+Release: 7%{?dist}
 License: MIT
 Summary: A package to obsolete retired packages
 URL: https://github.com/theforeman/pulpcore-packaging
@@ -11,6 +11,12 @@ Obsoletes:      python3-django-currentuser < 0.5.3-6
 Obsoletes:      python39-django-currentuser < 0.5.3-6
 Obsoletes:      python39-importlib-resources < 5.4.0-6
 Obsoletes:      python39-django-guardian < 2.4.0-7
+Obsoletes:      python39-aiodns < 3.0.0-4
+Obsoletes:      python39-aiohttp < 3.8.3-3
+Obsoletes:      python39-aiohttp-xmlrpc < 1.5.0-3
+Obsoletes:      python39-pexpect < 4.8.0-3
+Obsoletes:      python39-requests < 2.31.0-2
+Obsoletes:      python39-wcmatch < 8.3-3
 %endif
 
 %description
@@ -26,6 +32,9 @@ from the distribution for some reason.
 %files
 
 %changelog
+* Wed Jan 10 2024 Patrick Creech <pcreech@redhat.com> - 1.0-7
+- Obsolete packages to ensure consistent upgrads in older systems
+
 * Thu Dec 14 2023 Odilon Sousa <osousa@redhat.com> - 1.0-6
 - Dont obsolete pyyaml
 


### PR DESCRIPTION
Older systems that have been upgraded over many versions have some lingering packages needing to be removed

(cherry picked from commit 40683a7bc1f8a95a08a2fa286c52eff2607bc1a2)