### PR TITLE
Update python-urllib3 to 1.26.17 to fix CVE-2023-43804

### DIFF
--- a/packages/python-urllib3/python-urllib3.spec
+++ b/packages/python-urllib3/python-urllib3.spec
@@ -5,8 +5,8 @@
 %global pypi_name urllib3
 
 Name:           %{?scl_prefix}python-%{pypi_name}
-Version:        1.26.8
-Release:        2%{?dist}
+Version:        1.26.17
+Release:        1%{?dist}
 Summary:        HTTP library with thread-safe connection pooling, file post, and more
 
 License:        MIT
@@ -62,6 +62,9 @@ set -ex
 
 
 %changelog
+* Thu Jan 11 2024 Odilon Sousa <osousa@redhat.com> - 1.26.17-1
+- Release python-urllib3 1.26.17
+
 * Fri Apr 22 2022 Yanis Guenane <yguenane@redhat.com> - 1.26.8-2
 - Build against python 3.9
 

--- a/packages/python-urllib3/urllib3-1.26.17.tar.gz
+++ b/packages/python-urllib3/urllib3-1.26.17.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/j5/f1/SHA256E-s305031--24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21.tar.gz/SHA256E-s305031--24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21.tar.gz

--- a/packages/python-urllib3/urllib3-1.26.8.tar.gz
+++ b/packages/python-urllib3/urllib3-1.26.8.tar.gz
@@ -1,1 +1,0 @@
-../../.git/annex/objects/v3/1Z/SHA256E-s294280--0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c.tar.gz/SHA256E-s294280--0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c.tar.gz


### PR DESCRIPTION
(cherry picked from commit 050bbc858a0d3c007535c2658107bb4ff241c3cf)