### PR TITLE
Rewrite build_matrix.py to set an output

### DIFF
--- a/.github/workflows/update-pulp-packages.yml
+++ b/.github/workflows/update-pulp-packages.yml
@@ -27,10 +27,8 @@ jobs:
     - name: Sort Updated Libs
       run: git diff --unified=0 ${{github.event.before}} ${{github.sha}} automation/requirements.txt | grep -Po '(?<=^\+)(?!\+\+).*' > $PACKAGE_TO_UPDATE
     - name: Parse Package List
-      run: ./build_matrix.py
-    - name: Load Packages Matrix
       id: set-matrix
-      run: echo "matrix=$(jq -c . < ./packages.json)" >> $GITHUB_OUTPUT
+      run: ./build_matrix.py < $PACKAGE_TO_UPDATE
 
   bump-rpms:
     name: 'Bump ${{ matrix.package_name }} RPM ${{ matrix.new_version }}'

--- a/build_matrix.py
+++ b/build_matrix.py
@@ -1,20 +1,27 @@
 #!/usr/bin/env python3
 
-
 import json
+import os
+import sys
 
-def parse_package_list(file_path, output_path):
-    packages = []
-    with open(file_path, 'r') as file:
-        for line in file:
-            line = line.strip()
-            if line:
-                name, version = line.split('==')
-                packages.append({'package_name': name, 'new_version': version})
-    with open(output_path, 'w') as json_file:
-        json.dump(packages, json_file, indent=4)
 
-# Specify the path for package list file and output JSON file
-file_path = 'package_list.txt'
-output_path = 'packages.json'
-parse_package_list(file_path, output_path)
+def parse_package_list(lines):
+    for line in lines:
+        line = line.strip()
+        if line:
+            name, version = line.split('==')
+            yield {'package_name': name, 'new_version': version}
+
+
+def main():
+    packages = list(parse_package_list(sys.stdin.readlines()))
+
+    if 'GITHUB_OUTPUT' in os.environ:
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as github_output:
+            print(f'matrix={json.dumps(packages)}', file=github_output)
+
+    for package in packages:
+        print(package['package_name'], package['new_version'])
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Rather than using shell to set an output, this moves it into the matrix script itself. This is also done in foreman-packaging and works reliably.

It also reverts back to using include with matrix. This is because the output generated doesn't match a normal matrix definition. Normal matrices have multiple vectors and it runs for all possible combinations. You can also exclude some combinations, but more important here: you can include combinations. That's what build_matrix.py always generated: a list of combinations.