### PR TITLE
Update python-grpcio to 1.65.4

### DIFF
--- a/packages/python-grpcio/grpcio-1.56.0.tar.gz
+++ b/packages/python-grpcio/grpcio-1.56.0.tar.gz
@@ -1,1 +1,0 @@
-../../.git/annex/objects/32/WP/SHA256E-s24308553--4c08ee21b3d10315b8dc26f6c13917b20ed574cdbed2d2d80c53d5508fdcc0f2.tar.gz/SHA256E-s24308553--4c08ee21b3d10315b8dc26f6c13917b20ed574cdbed2d2d80c53d5508fdcc0f2.tar.gz

--- a/packages/python-grpcio/grpcio-1.65.4.tar.gz
+++ b/packages/python-grpcio/grpcio-1.65.4.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/0g/9x/SHA256E-s12254082--2a4f476209acffec056360d3e647ae0e14ae13dcf3dfb130c227ae1c594cbe39.tar.gz/SHA256E-s12254082--2a4f476209acffec056360d3e647ae0e14ae13dcf3dfb130c227ae1c594cbe39.tar.gz

--- a/packages/python-grpcio/python-grpcio.spec
+++ b/packages/python-grpcio/python-grpcio.spec
@@ -1,15 +1,13 @@
 %global python3_pkgversion 3.11
 %global __python3 /usr/bin/python3.11
-%{?python_disable_dependency_generator}
-
 
 # Created by pyp2rpm-3.3.8
 %global pypi_name grpcio
 %global srcname grpcio
 
 Name:           python-%{srcname}
-Version:        1.56.0
-Release:        5%{?dist}
+Version:        1.65.4
+Release:        1%{?dist}
 Summary:        HTTP/2-based RPC framework
 
 License:        Apache License 2.0
@@ -55,6 +53,9 @@ set -ex
 %{python3_sitearch}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Mon Aug 12 2024 Odilon Sousa <osousa@redhat.com> - 1.65.4-1
+- Release python-grpcio 1.65.4
+
 * Tue Jan 16 2024 Odilon Sousa <osousa@redhat.com> - 1.56.0-5
 - Remove SCL bits
 


### PR DESCRIPTION
(cherry picked from commit 255476f0f1dbd450110d6a7cfeae128cd3314aab)