### PR TITLE
Pin Django to 4.2 LTS (PostgreSQL 13 compatibility)

### DIFF
--- a/add_optional_packages.sh
+++ b/add_optional_packages.sh
@@ -2,3 +2,6 @@
 
 echo "django-storages[boto3,google,s3,azure]" >> automation/requirements.txt
 echo "psycopg[c]" >> automation/requirements.txt
+# Foreman only supports PostgreSQL 13, which Django 5.x dropped. Pin to 4.2 LTS.
+# Switch only if Foreman supports a newer PostgreSQL version.
+echo "Django~=4.2.0" >> automation/requirements.txt


### PR DESCRIPTION
## Problem

Foreman only supports PostgreSQL 13. Django 5.0+ dropped support for PostgreSQL < 14 ([Django 5.0 release notes](https://docs.djangoproject.com/en/5.0/releases/5.0/#dropped-support-for-postgresql-12-and-13)). Without a version pin the weekly automation (`generate-package-list.yml`) resolves the latest Django release (currently 5.2.x), which breaks all Foreman installations on PostgreSQL 13.

PR #2374 was opened by the automation and cannot be merged for this reason.

## Fix

Add `Django~=4.2.0` to `add_optional_packages.sh` so the automation is constrained to the Django 4.2 LTS series during dependency resolution.

## When to remove this pin

Remove when Foreman adds support for PostgreSQL 14+.