### PR TITLE
Add python-lazy-imports 1.2.0

### DIFF
--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -175,6 +175,7 @@
       <packagereq type="default">python3.12-json_stream_rs_tokenizer</packagereq>
       <packagereq type="default">python3.12-jsonschema</packagereq>
       <packagereq type="default">python3.12-keyring</packagereq>
+      <packagereq type="default">python3.12-lazy-imports</packagereq>
       <packagereq type="default">python3.12-ldap</packagereq>
       <packagereq type="default">python3.12-libcomps</packagereq>
       <packagereq type="default">python3.12-libcomps</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -239,6 +239,7 @@ tier4_packages:
     python-inflection: {}
     python-isodate: {}
     python-jeepney: {}
+    python-lazy-imports: {}
     python-lxml: {}
     python-marshmallow: {}
     python-more-itertools: {}

--- a/packages/python-lazy-imports/lazy_imports-1.2.0.tar.gz
+++ b/packages/python-lazy-imports/lazy_imports-1.2.0.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/26/2v/SHA256E-s24470--3c546b3c1e7c4bf62a07f897f6179d9feda6118e71ef6ecc47a339cab3d2e2d9.tar.gz/SHA256E-s24470--3c546b3c1e7c4bf62a07f897f6179d9feda6118e71ef6ecc47a339cab3d2e2d9.tar.gz

--- a/packages/python-lazy-imports/python-lazy-imports.spec
+++ b/packages/python-lazy-imports/python-lazy-imports.spec
@@ -1,0 +1,53 @@
+%global python3_pkgversion 3.12
+%global __python3 /usr/bin/python3.12
+
+# Created by pyp2rpm-3.3.3
+%global pypi_name lazy-imports
+%global src_name lazy_imports
+
+Name:           python%{python3_pkgversion}-%{pypi_name}
+Version:        1.2.0
+Release:        1%{?dist}
+Summary:        Tool to support lazy imports
+
+License:        Apache-2.0
+URL:            https://github.com/bachorp/lazy-imports
+Source0:        https://files.pythonhosted.org/packages/source/l/%{pypi_name}/%{src_name}-%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-pip
+BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-wheel
+BuildRequires:  pyproject-rpm-macros
+
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%description
+%{summary}
+
+
+%prep
+set -ex
+%autosetup -n %{src_name}-%{version}
+
+
+%build
+set -ex
+%pyproject_wheel
+
+
+%install
+set -ex
+%pyproject_install
+
+%files -n python%{python3_pkgversion}-%{pypi_name}
+%license LICENSE
+%doc README.md
+%{python3_sitelib}/%{src_name}
+%{python3_sitelib}/%{src_name}-%{version}.dist-info/
+
+
+%changelog
+* Thu Mar 26 2026 Odilon Sousa <osousa@redhat.com> - 1.2.0-1
+- Initial package.


### PR DESCRIPTION
New dependency required by `python-pulp-rpm-client >= 3.32.6`.

Repoclosure for PR #2216 failed with:
```
package: python3.12-pulp-rpm-client-3.32.6-1.el9.noarch
    (python3.12dist(lazy-imports) < 2 with python3.12dist(lazy-imports) >= 1)
```

Changes:
- Add `packages/python-lazy-imports/` with spec and tarball
- Register in `package_manifest.yaml`
- Add to `comps/comps-pulpcore-el9.xml`

Package details: pure Python, no runtime dependencies, Apache-2.0 license.