### PR TITLE
fix: correct psycopg_c spec path in find_package.py

### DIFF
--- a/find_package.py
+++ b/find_package.py
@@ -110,7 +110,6 @@ def find_packages(pkg, new_version):
         'poetry-core': 'poetry_core',
         'poetry-plugin-export': 'poetry_plugin_export',
         'galaxy-importer': 'galaxy_importer',
-        'psycopg_c': 'psycopg-c',
         'importlib-resources': 'importlib_resources',
         'ruamel-yaml': 'ruamel.yaml',
         'ruamel-yaml-clib': 'ruamel.yaml.clib',

--- a/test/test_find_packages.py
+++ b/test/test_find_packages.py
@@ -123,7 +123,6 @@ class TestFindPackages(unittest.TestCase):
             'poetry-core': 'poetry_core',
             'poetry-plugin-export': 'poetry_plugin_export',
             'galaxy-importer': 'galaxy_importer',
-            'psycopg_c': 'psycopg-c',
             'importlib-resources': 'importlib_resources',
             'ruamel-yaml': 'ruamel.yaml',
             'ruamel-yaml-clib': 'ruamel.yaml.clib',


### PR DESCRIPTION
## Problem

`psycopg_c` was never being auto-bumped alongside `psycopg`, even though `psycopg[c]` is installed via `add_optional_packages.sh` and `psycopg-c` does appear in `pip freeze`.

The `find_packages()` function has a `reverse_mappings` dict used to translate the mapped package name back to a directory name for the spec file path. The entry:

```python
'psycopg_c': 'psycopg-c',
```

caused it to look for `packages/python-psycopg-c/python-psycopg-c.spec` (hyphen), but the actual directory is `packages/python-psycopg_c/` (underscore). `rpmspec` raised `CalledProcessError`, the function returned early, and `psycopg_c` was never written to `packages-to-update.txt`.

## Fix

Remove the wrong reverse mapping entry. The fallback `reverse_mappings.get(pkg, pkg)` then returns `psycopg_c` unchanged, constructing the correct path `packages/python-psycopg_c/python-psycopg_c.spec`.

## Verification

```
$ echo "psycopg-c==3.2.13" | python3 find_package.py
3.2.10 < 3.2.13
RPM for Package psycopg_c needs to be updated from 3.2.10 to 3.2.13
```