### PR TITLE
Add python-backports-zstd 1.3.0

### DIFF
--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -48,6 +48,7 @@
       <packagereq type="default">python3.12-azure-storage-blob</packagereq>
       <packagereq type="default">python3.12-azure-storage-common</packagereq>
       <packagereq type="default">python3.12-backoff</packagereq>
+      <packagereq type="default">python3.12-backports-zstd</packagereq>
       <packagereq type="default">python3.12-bandersnatch</packagereq>
       <packagereq type="default">python3.12-beautifulsoup4</packagereq>
       <packagereq type="default">python3.12-bindep</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -159,6 +159,7 @@ tier4_packages:
     python-azure-storage-blob: {}
     python-azure-storage-common: {}
     python-backoff: {}
+    python-backports-zstd: {}
     python-bandersnatch: {}
     python-beautifulsoup4: {}
     python-bindep: {}

--- a/packages/python-backports-zstd/backports_zstd-1.3.0.tar.gz
+++ b/packages/python-backports-zstd/backports_zstd-1.3.0.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/2J/gm/SHA256E-s997138--e8b2d68e2812f5c9970cabc5e21da8b409b5ed04e79b4585dbffa33e9b45ebe2.tar.gz/SHA256E-s997138--e8b2d68e2812f5c9970cabc5e21da8b409b5ed04e79b4585dbffa33e9b45ebe2.tar.gz

--- a/packages/python-backports-zstd/python-backports-zstd.spec
+++ b/packages/python-backports-zstd/python-backports-zstd.spec
@@ -1,0 +1,64 @@
+%global python3_pkgversion 3.12
+%global __python3 /usr/bin/python3.12
+
+# C extension compiled with -g0 -flto (no debug symbols); suppress empty debugsource package
+%global debug_package %{nil}
+
+%global pypi_name backports.zstd
+%global pypi_srcname backports_zstd
+%global srcname backports-zstd
+
+Name:           python%{python3_pkgversion}-%{srcname}
+Version:        1.3.0
+Release:        1%{?dist}
+Summary:        Backport of the Python 3.14 compression.zstd module
+
+License:        PSF-2.0
+URL:            https://github.com/rogdham/backports.zstd
+Source0:        https://files.pythonhosted.org/packages/source/b/%{pypi_name}/%{pypi_srcname}-%{version}.tar.gz
+
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-wheel
+BuildRequires:  gcc
+BuildRequires:  libzstd-devel
+BuildRequires:  pyproject-rpm-macros
+
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
+
+%description
+%{summary}
+
+
+%prep
+set -ex
+%autosetup -n %{pypi_srcname}-%{version}
+# Fix PEP 639 license field (unsupported by RHEL 9 pip)
+sed -i 's/^license = "\(.*\)"/license = {text = "\1"}/' pyproject.toml
+sed -i '/^license-files/d' pyproject.toml
+# Lower setuptools build requirement to match RHEL 9 (ships 68.x, not 80+)
+# The >=80 requirement was driven by license-files support which we patch out above
+sed -i 's/setuptools>=80/setuptools/' pyproject.toml
+# Force system zstd linkage (replaces --system-zstd CLI flag)
+sed -i 's/_SYSTEM_ZSTD = False/_SYSTEM_ZSTD = True/' setup.py
+
+
+%build
+set -ex
+%pyproject_wheel
+
+
+%install
+set -ex
+%pyproject_install
+
+
+%files -n python%{python3_pkgversion}-%{srcname}
+%license LICENSE.txt LICENSE_zstd.txt
+%{python3_sitearch}/backports/zstd/
+%{python3_sitearch}/%{pypi_name}-%{version}.dist-info/
+
+
+%changelog
+* Mon Mar 30 2026 Odilon Sousa <osousa@redhat.com> - 1.3.0-1
+- Initial package.


### PR DESCRIPTION
Add python-backports-zstd 1.3.0 as a new package.

Backport of the Python 3.14 `compression.zstd` module. This is a runtime dependency needed by virtualenv 21.2.0 (#2354) and transitively by hatch (#2283).

**Package details:**
- PyPI: `backports.zstd`
- License: PSF-2.0
- C extension (arch-specific build, links against system `libzstd`)
- No Python runtime deps
- Fixes PEP 639 `license` string field in `pyproject.toml` for RHEL 9 pip compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)