### PR TITLE
Relax cryptography constraint in pulpcore to < 47.0

### DIFF
--- a/packages/python-pulpcore/python-pulpcore.spec
+++ b/packages/python-pulpcore/python-pulpcore.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.85.15
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Pulp Django Application and Related Modules
 
 License:        GPLv2+
@@ -39,7 +39,7 @@ Requires:       python%{python3_pkgversion}-backoff < 2.3
 Requires:       python%{python3_pkgversion}-click >= 8.1.0
 Requires:       python%{python3_pkgversion}-click < 8.3
 Requires:       python%{python3_pkgversion}-cryptography >= 44.0.3
-Requires:       python%{python3_pkgversion}-cryptography < 46.0
+Requires:       python%{python3_pkgversion}-cryptography < 47.0
 Requires:       python%{python3_pkgversion}-django-filter >= 23.1
 Requires:       python%{python3_pkgversion}-django-filter <= 25.1
 Requires:       python%{python3_pkgversion}-django-guid >= 3.3
@@ -169,6 +169,9 @@ set -ex
 
 
 %changelog
+* Mon Apr 06 2026 Odilon Sousa <osousa@redhat.com> - 3.85.15-2
+- Relax cryptography constraint to < 47.0 (upstream pyproject.toml allows < 47)
+
 * Wed Mar 25 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.85.15-1
 - Update to 3.85.15
 - Relax PyOpenSSL constraint to < 27.0 (upstream raised ceiling in 3.85.15)


### PR DESCRIPTION
## Summary

- Pulpcore spec had `cryptography < 46.0` but upstream `pyproject.toml` allows `cryptography>=44.0.3,<47.0`
- `python3.12-cryptography-46.0.6` was merged into the nightly repo, causing the installation pipeline to fail with a dependency conflict
- Updated upper bound to `< 47.0` to match upstream

## Root cause

Build #938 of `foreman-pipeline-pulpcore-rpm-nightly` failed on both almalinux9 and centos9-stream:
```
Problem: cannot install both python3.12-cryptography-46.0.6 from pulpcore
  and python3.12-cryptography-41.0.7 from appstream
  - python3.12-pulpcore-3.85.15 requires cryptography < 46.0
```

Upstream reference: https://github.com/pulp/pulpcore/blob/3.85/pyproject.toml#L28