### PR TITLE
Fix cryptography requirement for pyOpenSSL 26.0.0

### DIFF
--- a/packages/python-pyOpenSSL/python-pyOpenSSL.spec
+++ b/packages/python-pyOpenSSL/python-pyOpenSSL.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        26.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python wrapper module around the OpenSSL library
 
 License:        Apache License, Version 2.0
@@ -19,8 +19,8 @@ BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-setuptools
 
 
-Requires:       python%{python3_pkgversion}-cryptography >= 41.0.5
-Requires:       python%{python3_pkgversion}-cryptography < 46
+Requires:       python%{python3_pkgversion}-cryptography >= 46.0.0
+Requires:       python%{python3_pkgversion}-cryptography < 47
 Requires:       python%{python3_pkgversion}-typing-extensions >= 4.9.0
 
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
@@ -54,6 +54,9 @@ set -ex
 
 
 %changelog
+* Tue Apr 07 2026 Odilon Sousa <osousa@redhat.com> - 26.0.0-2
+- Update cryptography requirement to >= 46.0.0, < 47 (upstream pyOpenSSL 26.0.0)
+
 * Wed Apr 01 2026 Foreman Packaging Automation <packaging@theforeman.org> - 26.0.0-1
 - Update to 26.0.0
 


### PR DESCRIPTION
## Summary

- pyOpenSSL 26.0.0 upstream requires `cryptography>=46.0.0,<47`
- The spec had a stale `>=41.0.5,<46` from a previous release that was never updated when pyOpenSSL 26.0.0 landed
- Updated both bounds to match upstream exactly

Upstream reference: https://pypi.org/pypi/pyOpenSSL/26.0.0/json (`requires_dist`: `cryptography<47,>=46.0.0`)