### PR TITLE
Fix pulpcore distutils import failure on Python 3.12

### DIFF
--- a/packages/python-pulpcore/python-pulpcore.spec
+++ b/packages/python-pulpcore/python-pulpcore.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.85.15
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Pulp Django Application and Related Modules
 
 License:        GPLv2+
@@ -22,6 +22,7 @@ BuildRequires:  python%{python3_pkgversion}-wheel >= 0.29.0
 BuildRequires:  pyproject-rpm-macros
 
 
+Requires:       python%{python3_pkgversion}-setuptools
 Requires:       python%{python3_pkgversion}-django >= 4.2.0
 Conflicts:      python%{python3_pkgversion}-django == 5.0
 Conflicts:      python%{python3_pkgversion}-django == 5.1
@@ -169,6 +170,9 @@ set -ex
 
 
 %changelog
+* Thu Apr 09 2026 Odilon Sousa <osousa@redhat.com> - 3.85.15-4
+- Add python3.12-setuptools as runtime Requires (provides distutils shim for Python 3.12, required by pulpcore/app/tasks/export.py)
+
 * Wed Apr 08 2026 Odilon Sousa <osousa@redhat.com> - 3.85.15-3
 - Relax jq constraint to < 1.11.0 (upstream pulpcore 3.85 allows < 1.11.0)
 


### PR DESCRIPTION
## Problem

The nightly publication pipeline (run #939) fails with:

```
ModuleNotFoundError: No module named 'distutils'
```

Traceback:
```
pulpcore/app/viewsets/base.py → pulpcore/app/tasks/__init__.py
  → pulpcore/app/tasks/export.py:8: from distutils.util import strtobool
```

`distutils` was removed from Python 3.12 stdlib. It is now provided by `setuptools` as a compatibility shim, but `setuptools` was only a `BuildRequires` in the spec, not a runtime `Requires`. This means it may not be installed on the target system.

## Fix

Add `python3.12-setuptools` as a `Requires` so it is guaranteed to be present at runtime.

The proper long-term fix is for upstream pulpcore to replace `distutils.util.strtobool` with a Python 3.12-compatible alternative, but this packaging fix unblocks the nightly pipeline immediately.