### PR TITLE
Add python-rfc3986 2.0.0

### DIFF
--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -280,6 +280,7 @@
       <packagereq type="default">python3.12-requests-oauthlib</packagereq>
       <packagereq type="default">python3.12-requests-toolbelt</packagereq>
       <packagereq type="default">python3.12-requirements-parser</packagereq>
+      <packagereq type="default">python3.12-rfc3986</packagereq>
       <packagereq type="default">python3.12-rfc3161-client</packagereq>
       <packagereq type="default">python3.12-rhsm</packagereq>
       <packagereq type="default">python3.12-rich</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -264,6 +264,7 @@ tier4_packages:
     python-python3-openid: {}
     python-requests-oauthlib: {}
     python-requests-toolbelt: {}
+    python-rfc3986: {}
     python-rfc3161-client: {}
     python-rhsm: {}
     python-s3transfer: {}

--- a/packages/python-rfc3986/python-rfc3986.spec
+++ b/packages/python-rfc3986/python-rfc3986.spec
@@ -1,0 +1,53 @@
+%global python3_pkgversion 3.12
+%global __python3 /usr/bin/python3.12
+
+# Created by pyp2rpm-3.3.3
+%global pypi_name rfc3986
+
+Name:           python%{python3_pkgversion}-%{pypi_name}
+Version:        2.0.0
+Release:        1%{?dist}
+Summary:        Validating URI References per the RFC
+
+License:        Apache-2.0
+URL:            https://python-rfc3986.readthedocs.io
+Source0:        https://files.pythonhosted.org/packages/source/r/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-pip
+BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-wheel
+BuildRequires:  pyproject-rpm-macros
+
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%description
+%{summary}
+
+
+%prep
+set -ex
+%autosetup -n %{pypi_name}-%{version}
+
+
+%build
+set -ex
+%pyproject_wheel
+
+
+%install
+set -ex
+%pyproject_install
+
+
+%files -n python%{python3_pkgversion}-%{pypi_name}
+%license LICENSE
+%doc README.rst
+%{python3_sitelib}/%{pypi_name}
+%{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
+
+
+%changelog
+* Tue Apr 14 2026 Odilon Sousa <osousa@redhat.com> - 2.0.0-1
+- Initial package.

--- a/packages/python-rfc3986/rfc3986-2.0.0.tar.gz
+++ b/packages/python-rfc3986/rfc3986-2.0.0.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/vq/KG/SHA256E-s49026--97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c.tar.gz/SHA256E-s49026--97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c.tar.gz


### PR DESCRIPTION
URI parsing library required by python-pypi-attestations.