### PR TITLE
Add python-pypi-attestations 0.0.28

### DIFF
--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -261,6 +261,7 @@
       <packagereq type="default">python3.12-pygments</packagereq>
       <packagereq type="default">python3.12-pygobject</packagereq>
       <packagereq type="default">python3.12-pygtrie</packagereq>
+      <packagereq type="default">python3.12-pypi-attestations</packagereq>
       <packagereq type="default">python3.12-pyjwkest</packagereq>
       <packagereq type="default">python3.12-pyjwt</packagereq>
       <packagereq type="default">python3.12-pyjwt+crypto</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -260,6 +260,7 @@ tier4_packages:
     python-psycopg_c: {}
     python-pyasn1: {}
     python-pyasn1-modules: {}
+    python-pypi-attestations: {}
     python-pygobject: {}
     python-python3-openid: {}
     python-requests-oauthlib: {}

--- a/packages/python-pypi-attestations/pypi_attestations-0.0.28.tar.gz
+++ b/packages/python-pypi-attestations/pypi_attestations-0.0.28.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/qZ/8W/SHA256E-s124805--e5e75beaddbb674c390ed1a43cb32b7274990da6be7190c812a530b18db6137f.tar.gz/SHA256E-s124805--e5e75beaddbb674c390ed1a43cb32b7274990da6be7190c812a530b18db6137f.tar.gz

--- a/packages/python-pypi-attestations/python-pypi-attestations.spec
+++ b/packages/python-pypi-attestations/python-pypi-attestations.spec
@@ -1,0 +1,70 @@
+%global python3_pkgversion 3.12
+%global __python3 /usr/bin/python3.12
+
+# Created by pyp2rpm-3.3.3
+%global pypi_name pypi-attestations
+%global src_name pypi_attestations
+
+Name:           python%{python3_pkgversion}-%{pypi_name}
+Version:        0.0.28
+Release:        1%{?dist}
+Summary:        A library to convert between Sigstore Bundles and PEP-740 Attestation objects
+
+License:        Apache-2.0
+URL:            https://github.com/trailofbits/pypi-attestations
+Source0:        https://files.pythonhosted.org/packages/source/p/%{src_name}/%{src_name}-%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-pip
+BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-setuptools-scm
+BuildRequires:  python%{python3_pkgversion}-wheel
+BuildRequires:  pyproject-rpm-macros
+
+Requires:       python%{python3_pkgversion}-cryptography
+Requires:       python%{python3_pkgversion}-packaging
+Requires:       python%{python3_pkgversion}-pyasn1 >= 0.6
+Conflicts:      python%{python3_pkgversion}-pyasn1 >= 0.7
+Requires:       python%{python3_pkgversion}-pydantic >= 2.10.0
+Requires:       python%{python3_pkgversion}-requests
+Requires:       python%{python3_pkgversion}-rfc3986
+Requires:       python%{python3_pkgversion}-sigstore >= 4.0
+Requires:       python%{python3_pkgversion}-sigstore < 5.0
+Requires:       python%{python3_pkgversion}-sigstore-models
+
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%description
+%{summary}
+
+
+%prep
+set -ex
+%autosetup -n %{src_name}-%{version}
+# Fix PEP 639 license field (RHEL 9 pip does not support SPDX string format)
+sed -i 's/^license = "\(.*\)"/license = {text = "\1"}/' pyproject.toml
+sed -i '/^license-files/d' pyproject.toml
+
+
+%build
+set -ex
+SETUPTOOLS_SCM_PRETEND_VERSION=%{version} %pyproject_wheel
+
+
+%install
+set -ex
+%pyproject_install
+
+
+%files -n python%{python3_pkgversion}-%{pypi_name}
+%license LICENSE
+%doc README.md
+%{_bindir}/%{pypi_name}
+%{python3_sitelib}/%{src_name}
+%{python3_sitelib}/%{src_name}-%{version}.dist-info/
+
+
+%changelog
+* Tue Apr 14 2026 Odilon Sousa <osousa@redhat.com> - 0.0.28-1
+- Initial package.


### PR DESCRIPTION
New runtime dep for python-pulp-python >= 3.27.0 (PEP 740 attestations).