### PR TITLE
Add python3.12-rfc3161-client to comps.xml

### DIFF
--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -279,6 +279,7 @@
       <packagereq type="default">python3.12-requests-oauthlib</packagereq>
       <packagereq type="default">python3.12-requests-toolbelt</packagereq>
       <packagereq type="default">python3.12-requirements-parser</packagereq>
+      <packagereq type="default">python3.12-rfc3161-client</packagereq>
       <packagereq type="default">python3.12-rhsm</packagereq>
       <packagereq type="default">python3.12-rich</packagereq>
       <packagereq type="default">python3.12-rq</packagereq>


### PR DESCRIPTION
Fixup: python-rfc3161-client was merged without the comps.xml entry.