### PR TITLE
Update pydantic pydantic-core requirement to 2.46.0

### DIFF
--- a/packages/python-pydantic/python-pydantic.spec
+++ b/packages/python-pydantic/python-pydantic.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.13.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Data validation using Python type hints
 
 License:        MIT
@@ -21,7 +21,7 @@ BuildRequires:  python%{python3_pkgversion}-hatch_fancy_pypi_readme >= 22.5.0
 
 Requires:  python%{python3_pkgversion}-typing-extensions >= 4.12.2
 Requires:  python%{python3_pkgversion}-annotated-types >= 0.6.0
-Requires:  python%{python3_pkgversion}-pydantic-core == 2.41.5
+Requires:  python%{python3_pkgversion}-pydantic-core == 2.46.0
 Requires:  python%{python3_pkgversion}-typing-inspection >= 0.4.0
 
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
@@ -63,6 +63,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Wed Apr 15 2026 Odilon Sousa <osousa@redhat.com> - 2.13.0-2
+- Update pydantic-core requirement to 2.46.0
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.13.0-1
 - Update to 2.13.0
 - Add +email metapackage for pydantic[email] extra (requires email-validator)


### PR DESCRIPTION
Fix repoclosure failure in pulpcore-nightly-rpm-pipeline #1127.

`python-pydantic 2.13.0-1` was released with `Requires: python3.12-pydantic-core == 2.41.5`, but pydantic-core was updated to 2.46.0 in the same release cycle. Pydantic 2.13.0 upstream requires `pydantic-core==2.46.0`.

- Bumps `Release` to `2`
- Updates `Requires: pydantic-core` pin from `2.41.5` to `2.46.0`