### PR TITLE
Add python-pysequoia 0.1.32

### DIFF
--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -274,6 +274,7 @@
       <packagereq type="default">python3.12-pyproject_hooks</packagereq>
       <packagereq type="default">python3.12-pyproject-metadata</packagereq>
       <packagereq type="default">python3.12-pyrsistent</packagereq>
+      <packagereq type="default">python3.12-pysequoia</packagereq>
       <packagereq type="default">python3.12-python3-openid</packagereq>
       <packagereq type="default">python3.12-pytz</packagereq>
       <packagereq type="default">python3.12-pyyaml</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -323,6 +323,7 @@ tier4_packages:
     python-pypi-simple: {}
     python-pyproject_hooks: {}
     python-pyrsistent: {}
+    python-pysequoia: {}
     python-pytz: {}
     python-rapidfuzz: {}
     python-redis: {}

--- a/packages/python-pysequoia/pysequoia-0.1.32-vendor.tar.xz
+++ b/packages/python-pysequoia/pysequoia-0.1.32-vendor.tar.xz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/Vj/X8/SHA256E-s14100152--fc263c9079b222bf5e9b15863aceeaac5d7cd4736bfbcc6db238a254800a5155.tar.xz/SHA256E-s14100152--fc263c9079b222bf5e9b15863aceeaac5d7cd4736bfbcc6db238a254800a5155.tar.xz

--- a/packages/python-pysequoia/pysequoia-0.1.32.tar.gz
+++ b/packages/python-pysequoia/pysequoia-0.1.32.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/pF/jj/SHA256E-s285515--baa5892b3e68dbf4492fcd4b5beb10bdeed8080ca5e8f57725606a824b65753f.tar.gz/SHA256E-s285515--baa5892b3e68dbf4492fcd4b5beb10bdeed8080ca5e8f57725606a824b65753f.tar.gz

--- a/packages/python-pysequoia/python-pysequoia.spec
+++ b/packages/python-pysequoia/python-pysequoia.spec
@@ -1,0 +1,69 @@
+%global python3_pkgversion 3.12
+%global __python3 /usr/bin/python3.12
+%global debug_package %{nil}
+
+%global pypi_name pysequoia
+
+Name:           python%{python3_pkgversion}-%{pypi_name}
+Version:        0.1.32
+Release:        1%{?dist}
+Summary:        Provides OpenPGP facilities using Sequoia-PGP library
+
+License:        Apache-2.0
+URL:            https://github.com/wiktor-k/pysequoia
+Source0:        https://files.pythonhosted.org/packages/source/p/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+Source1:        https://downloads.theforeman.org/vendor/%{pypi_name}-%{version}-vendor.tar.xz
+
+## vendor rust content generated via:
+## curl -sL https://files.pythonhosted.org/packages/source/p/pysequoia/pysequoia-0.1.32.tar.gz -o /tmp/pysequoia-0.1.32.tar.gz
+## cd /tmp && tar xzf pysequoia-0.1.32.tar.gz && cd pysequoia-0.1.32
+## cargo vendor-filterer --all-features --platform=x86_64-unknown-linux-gnu
+## tar Jcf ../pysequoia-0.1.32-vendor.tar.xz vendor/
+
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-pip
+BuildRequires:  python%{python3_pkgversion}-maturin >= 1
+BuildRequires:  python%{python3_pkgversion}-maturin < 2
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  rust-toolset
+BuildRequires:  openssl-devel
+BuildRequires:  gcc
+
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+Obsoletes:      python3.11-%{pypi_name} < %{version}-%{release}
+
+%description
+Provides OpenPGP facilities for Python using the Sequoia PGP library.
+Supports signing, verification, encryption, and key management.
+
+
+%prep
+set -ex
+%autosetup -n %{pypi_name}-%{version}
+# Fix PEP 639 license field (RHEL 9 pip does not support SPDX string format)
+sed -i 's/^license = "\(.*\)"/license = {text = "\1"}/' pyproject.toml
+sed -i '/^license-files/d' pyproject.toml
+%cargo_prep -V 1
+
+
+%build
+set -ex
+%pyproject_wheel
+
+
+%install
+set -ex
+%pyproject_install
+
+
+%files -n python%{python3_pkgversion}-%{pypi_name}
+%license LICENSE
+%{python3_sitearch}/%{pypi_name}
+%{python3_sitearch}/%{pypi_name}-%{version}.dist-info/
+
+
+%changelog
+* Fri Apr 17 2026 Odilon Sousa <osousa@redhat.com> - 0.1.32-1
+- Initial package.
+- Required by pulp-container >= 2.27.6 for OpenPGP support


### PR DESCRIPTION
## Summary

Add \`python-pysequoia 0.1.32\` — Python bindings for Sequoia PGP library.

**Required by:** \`pulp-container >= 2.27.6\` (PR #2522) which added \`pysequoia==0.1.32\` as a runtime dependency for OpenPGP signing support.

## Technical details

- Uses **maturin** (Rust extension) build system
- Pure Rust crypto via \`sequoia-openpgp\` with \`crypto-rust\` feature (no system OpenSSL dependency)
- License: Apache-2.0

## Blocker: Vendor tarball upload required

CI will fail until the Rust vendor tarball is uploaded to \`downloads.theforeman.org/vendor/\`. The tarball has been generated locally at \`/tmp/pysequoia-0.1.32-vendor.tar.xz\` (14MB, 213 crates). After uploading, run \`obal source python-pysequoia\` to register it in git-annex.

## Dependency chain

- \`pulp-container 2.27.6\` → \`pysequoia 0.1.32\` ← this PR
- maturin is a BuildRequires (already in repo at 1.12.6, needs update to 1.13.x via PR #2456)