### PR TITLE
fix(dependabot): merge pulp-cli-deb group into pulp-cli-deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,15 +13,16 @@ updates:
        # Specify a name for the group, which will be used in pull request titles
        # and branch names
        pulp-cli-deps:
-          # Define patterns to include dependencies in the group (based on
-          # dependency name)
-          applies-to: version-updates # Applies the group rule to version updates
+          # pulp-cli, pulp-glue, pulp-cli-deb and pulp-glue-deb are versioned
+          # together: pulp-cli-deb pins an exact pulp-glue-deb version and a
+          # strict upper bound on pulp-cli/pulp-glue. Grouping all four ensures
+          # dependabot only opens a PR when a compatible set exists for all of
+          # them simultaneously, preventing pulp-cli/pulp-glue from jumping past
+          # the ceiling that the current pulp-cli-deb/pulp-glue-deb supports.
+          applies-to: version-updates
           patterns:
             - "pulp-cli"
             - "pulp-glue"
-       pulp-cli-deb-deps:
-          applies-to: version-updates
-          patterns:
             - "pulp-cli-deb"
             - "pulp-glue-deb"
     labels:


### PR DESCRIPTION
## Problem

`pulp-cli-deps` and `pulp-cli-deb-deps` were two separate dependabot groups. Dependabot resolves each group independently with no cross-group compatibility checking, so it could bump `pulp-cli`/`pulp-glue` past the ceiling that the current `pulp-cli-deb`/`pulp-glue-deb` supports.

**Example:** PR #2529 bumped `pulp-cli` and `pulp-glue` to 0.39.0 while `pulp-cli-deb==0.4.3` requires `pulp-cli<0.38` — an incompatible combination.

## Fix

Merge all four packages into a single `pulp-cli-deps` group. Dependabot now resolves one compatible set across all of them before opening a PR. Since no `pulp-cli-deb` release currently supports `pulp-cli>=0.38`, dependabot will hold off until upstream ships a compatible version.

## Dependency chain

```
pulp-cli-deb==0.4.3
  requires: pulp-cli<0.38,>=0.23.2
  requires: pulp-glue-deb==0.4.3
             requires: pulp-glue<0.38,>=0.23.2
```

All four packages must advance together.