### PR TITLE
Pin psycopg and psycopg_c to 3.2.x

### DIFF
--- a/add_optional_packages.sh
+++ b/add_optional_packages.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 echo "django-storages[boto3,google,s3,azure]" >> automation/requirements.txt
-echo "psycopg[c]" >> automation/requirements.txt
+# psycopg 3.3.x dropped setup.py and requires setuptools >= 80.3.1 to build the C extension.
+# RHEL 9 only ships setuptools 68.x. Pin to 3.2.x until a build fix is available.
+echo "psycopg[c]~=3.2.0" >> automation/requirements.txt
 # Foreman only supports PostgreSQL 13, which Django 5.x dropped. Pin to 4.2 LTS.
 # Switch only if Foreman supports a newer PostgreSQL version.
 echo "Django~=4.2.0" >> automation/requirements.txt


### PR DESCRIPTION
## Problem

psycopg 3.3.x dropped `setup.py` and moved C extension configuration to
`[[tool.setuptools.ext-modules]]` in `pyproject.toml`. This key requires
`setuptools >= 80.3.1` to build. RHEL 9 only ships
`python3.12-setuptools 68.2.2`, which fails validation on that key and
cannot compile the C extension.

PRs #2498 and #2503 have been closed as a result.

## Fix

Pin `psycopg[c]~=3.2.0` in `add_optional_packages.sh` so the weekly
automation does not generate new 3.3.x bump PRs until a build fix is
available for RHEL 9.

## Unpin when

`python3.12-setuptools >= 80.3.1` is available in the RHEL 9 COPR
buildroot, or an alternative spec fix is found.