### PR TITLE
Fix pydantic pydantic-core requirement to 2.46.3

### DIFF
--- a/packages/python-pydantic/python-pydantic.spec
+++ b/packages/python-pydantic/python-pydantic.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.13.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Data validation using Python type hints
 
 License:        MIT
@@ -21,7 +21,7 @@ BuildRequires:  python%{python3_pkgversion}-hatch_fancy_pypi_readme >= 22.5.0
 
 Requires:  python%{python3_pkgversion}-typing-extensions >= 4.12.2
 Requires:  python%{python3_pkgversion}-annotated-types >= 0.6.0
-Requires:  python%{python3_pkgversion}-pydantic-core == 2.46.0
+Requires:  python%{python3_pkgversion}-pydantic-core == 2.46.3
 Requires:  python%{python3_pkgversion}-typing-inspection >= 0.4.0
 
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
@@ -63,6 +63,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Mon Apr 27 2026 Odilon Sousa <osousa@redhat.com> - 2.13.3-2
+- Update pydantic-core requirement to 2.46.3
+
 * Wed Apr 22 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.13.3-1
 - Update to 2.13.3
 


### PR DESCRIPTION
## Problem

`python-pydantic 2.13.3-1` was auto-generated with `Requires: pydantic-core == 2.46.0`, but
`pydantic-core` was subsequently bumped to `2.46.3` in the same release cycle. Since the
requirement is an exact `==` pin, `pydantic-core 2.46.3` does not satisfy it — leaving
`el9-pulpcore-nightly-staging` in a broken repoclosure state.

This causes repoclosure to fail on every PR that checks against nightly-staging:

```
package: python3.12-pydantic-2.13.3-1.el9.noarch from el9-pulpcore-nightly-staging
  unresolved deps (1):
    python3.12-pydantic-core = 2.46.0
```

## Fix

Update `Requires: pydantic-core == 2.46.0` → `== 2.46.3`, matching what pydantic 2.13.3
declares in its PyPI metadata (`pydantic-core==2.46.3`).

Bump `Release` to `2`.

## Verification

```
curl -s https://pypi.org/pypi/pydantic/2.13.3/json | python3 -c \
  "import json,sys; [print(r) for r in json.load(sys.stdin)['info']['requires_dist'] if 'pydantic' in r]"
# pydantic-core==2.46.3
```