### PR TITLE
Update python-poetry_core to 2.4.0

### DIFF
--- a/packages/python-poetry_core/poetry_core-2.3.2.tar.gz
+++ b/packages/python-poetry_core/poetry_core-2.3.2.tar.gz
@@ -1,1 +1,0 @@
-../../.git/annex/objects/JV/kK/SHA256E-s382768--20cb71be27b774628da9f384effd9183dfceb53bcef84063248a8672aa47031f.tar.gz/SHA256E-s382768--20cb71be27b774628da9f384effd9183dfceb53bcef84063248a8672aa47031f.tar.gz

--- a/packages/python-poetry_core/poetry_core-2.4.0.tar.gz
+++ b/packages/python-poetry_core/poetry_core-2.4.0.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/Px/X3/SHA256E-s413541--4e8c7496cf797998ffc493f2e23eba4b038c894c08eadacdcdf688945de6b43a.tar.gz/SHA256E-s413541--4e8c7496cf797998ffc493f2e23eba4b038c894c08eadacdcdf688945de6b43a.tar.gz

--- a/packages/python-poetry_core/python-poetry_core.spec
+++ b/packages/python-poetry_core/python-poetry_core.spec
@@ -3,7 +3,7 @@
 %global pypi_name poetry_core
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
-Version:        2.3.2
+Version:        2.4.0
 Release:        1%{?dist}
 Summary:        Poetry PEP 517 Build Backend
 
@@ -47,6 +47,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Wed May 06 2026 Odilon Sousa <osousa@redhat.com> - 2.4.0-1
+- Release python-poetry_core 2.4.0
+
 * Tue Mar 31 2026 Odilon Sousa <osousa@redhat.com> - 2.3.2-1
 - Release python-poetry_core 2.3.2
 


### PR DESCRIPTION
Update python-poetry_core from 2.3.2 to 2.4.0.

Required by python-poetry 2.4.0 (PR #2582), which pins `poetry-core == 2.4.0`.

This unblocks the staging repoclosure failure where poetry 2.3.4 requires
`installer < 0.8` and `findpython < 0.8` — versions now superseded in the
staging repo. Landing poetry 2.4.0 (which accepts installer >= 1.0 and
findpython < 0.9) resolves that breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)