### PR TITLE
Fix pulpcore pulp-glue upper bound: < 0.39 → < 0.40

### DIFF
--- a/packages/python-pulpcore/python-pulpcore.spec
+++ b/packages/python-pulpcore/python-pulpcore.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.105.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Pulp Django Application and Related Modules
 
 License:        GPLv2+
@@ -76,7 +76,7 @@ Requires:       python%{python3_pkgversion}-json_stream < 2.5
 Requires:       python%{python3_pkgversion}-jq >= 1.6.0
 Requires:       python%{python3_pkgversion}-jq < 1.12.0
 Requires:       python%{python3_pkgversion}-pulp-glue >= 0.30.0
-Requires:       python%{python3_pkgversion}-pulp-glue < 0.39
+Requires:       python%{python3_pkgversion}-pulp-glue < 0.40
 Requires:       python%{python3_pkgversion}-pyOpenSSL < 27.0
 Requires:       python%{python3_pkgversion}-opentelemetry_api >= 1.27
 Requires:       python%{python3_pkgversion}-opentelemetry_api < 1.41
@@ -177,6 +177,9 @@ set -ex
 
 
 %changelog
+* Fri May 29 2026 Odilon Sousa <osousa@redhat.com> - 3.105.7-2
+- Relax pulp-glue upper bound to < 0.40 (upstream requires pulp-glue<0.40,>=0.30.0)
+
 * Thu May 14 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.105.7-1
 - Update to 3.105.7
 


### PR DESCRIPTION
## Problem

`python-pulpcore 3.105.7-1` has `Requires: python3.12-pulp-glue < 0.39` but upstream pulpcore 3.105.7 declares `pulp-glue<0.40,>=0.30.0`.

`pulp-glue 0.39.1` is now in `pulpcore-nightly-staging` (along with `pulp-cli 0.39.1` which requires `pulp-glue==0.39.1`). This causes **repoclosure to fail on every PR build** that runs against staging:

```
nothing provides python3.12-pulp-glue < 0.39
  needed by python3.12-pulpcore-3.105.7-1.el9.noarch
```

## Fix

Bump `Release: 1 → 2`, update the upper bound to match upstream:

```
Requires: python3.12-pulp-glue < 0.40   # was < 0.39
```

Verified against upstream PyPI metadata:
- `pulpcore 3.105.7`: `pulp-glue<0.40,>=0.30.0`
- `pulp-cli 0.39.1`: `pulp-glue==0.39.1`
- `pulp-glue 0.39.1` in nightly-staging ✓

## Test plan
- [ ] COPR scratch build passes
- [ ] repoclosure passes (no more `pulp-glue < 0.39` conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)