### PR TITLE
Fix stale dep bounds in pulp-cli-deb and pulp-glue-deb

### DIFF
--- a/packages/python-pulp-cli-deb/python-pulp-cli-deb.spec
+++ b/packages/python-pulp-cli-deb/python-pulp-cli-deb.spec
@@ -8,7 +8,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.4.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Command line interface (CLI) for Pulp's pulp_deb plugin.
 
 License:        GPLv2+
@@ -23,7 +23,7 @@ BuildRequires:  python%{python3_pkgversion}-wheel
 BuildRequires:  pyproject-rpm-macros
 
 Requires:       python%{python3_pkgversion}-pulp-cli >= 0.23.2
-Requires:       python%{python3_pkgversion}-pulp-cli < 0.38
+Requires:       python%{python3_pkgversion}-pulp-cli < 0.40
 Requires:       python%{python3_pkgversion}-click
 Requires:       python%{python3_pkgversion}-setuptools
 Requires:       python%{python3_pkgversion}-pulp-glue-deb == %{version}
@@ -60,6 +60,9 @@ set -ex
 
 
 %changelog
+* Fri May 29 2026 Odilon Sousa <osousa@redhat.com> - 0.4.4-2
+- Relax pulp-cli upper bound to < 0.40 (upstream: pulp-cli<0.40,>=0.23.2)
+
 * Thu May 14 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.4.4-1
 - Update to 0.4.4
 

--- a/packages/python-pulp-glue-deb/python-pulp-glue-deb.spec
+++ b/packages/python-pulp-glue-deb/python-pulp-glue-deb.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.4.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Version agnostic glue library to talk to pulpcore's REST API. (deb plugin)
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -23,7 +23,7 @@ BuildRequires:  python%{python3_pkgversion}-wheel
 BuildRequires:  pyproject-rpm-macros
 
 Requires:       python%{python3_pkgversion}-pulp-glue >= 0.23.2
-Requires:       python%{python3_pkgversion}-pulp-glue < 0.33
+Requires:       python%{python3_pkgversion}-pulp-glue < 0.40
 
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
@@ -53,6 +53,9 @@ set -ex
 %{python3_sitelib}/%{srcname}-%{version}.dist-info/
 
 %changelog
+* Fri May 29 2026 Odilon Sousa <osousa@redhat.com> - 0.4.4-2
+- Relax pulp-glue upper bound to < 0.40 (upstream: pulp-glue<0.40,>=0.23.2)
+
 * Thu May 14 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.4.4-1
 - Update to 0.4.4
 


### PR DESCRIPTION
## Problem

Both `pulp-cli-deb 0.4.4` and `pulp-glue-deb 0.4.4` have stale upper bounds
on their core dependencies, blocking the nightly staging repoclosure (pipeline #1185):

```
package: python3.12-pulp-cli-deb-0.4.4-1.el9.noarch
  unresolved deps (1):
    python3.12-pulp-cli < 0.38       ← only 0.39.1 available in staging

package: python3.12-pulp-glue-deb-0.4.4-1.el9.x86_64
  unresolved deps (1):
    python3.12-pulp-glue < 0.33      ← only 0.39.1 available in staging
```

## Fix

| Package | Old bound | New bound | Upstream (PyPI) |
|---------|-----------|-----------|-----------------|
| pulp-cli-deb | `pulp-cli < 0.38` | `pulp-cli < 0.40` | `pulp-cli<0.40,>=0.23.2` |
| pulp-glue-deb | `pulp-glue < 0.33` | `pulp-glue < 0.40` | `pulp-glue<0.40,>=0.23.2` |

Both `pulp-cli-deb 0.4.4` and `pulp-glue-deb 0.4.4` are the latest upstream
releases — this is a Release bump to align the spec with upstream metadata.

## Note

After this PR, one repoclosure failure remains (separate issue, human decision needed):
`pulp-glue 0.39.1` requires `pydantic<2.13` but `pydantic 2.13.4` is in staging.
Neither 0.39.1 nor 0.39.2 have relaxed this constraint upstream.

## Test plan
- [ ] COPR scratch build passes for both packages
- [ ] repoclosure passes (pulp-cli-deb and pulp-glue-deb constraints resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)