### PR TITLE
Fix pulp-glue pydantic upper bound: < 2.13 → < 2.14

### DIFF
--- a/packages/python-pulp-glue/python-pulp-glue.spec
+++ b/packages/python-pulp-glue/python-pulp-glue.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.39.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Version agnostic glue library to talk to pulpcore's REST API
 
 License:        GPLv2+
@@ -26,7 +26,7 @@ Requires:       python%{python3_pkgversion}-multidict < 6.8
 Requires:       python%{python3_pkgversion}-packaging >= 22.0
 Requires:       python%{python3_pkgversion}-packaging <= 26.2
 Requires:       python%{python3_pkgversion}-pydantic >= 2.9.2
-Requires:       python%{python3_pkgversion}-pydantic < 2.13
+Requires:       python%{python3_pkgversion}-pydantic < 2.14
 Requires:       python%{python3_pkgversion}-requests >= 2.24.0
 Requires:       python%{python3_pkgversion}-requests < 2.34
 
@@ -43,6 +43,9 @@ set -ex
 %autosetup -n %{pypi_name_u}-%{version}
 # setuptools < 70 (RHEL 9) does not support PEP 639 bare SPDX license strings
 sed -i 's/^license = "\(.*\)"$/license = {text = "\1"}/' pyproject.toml
+# upstream pins pydantic<2.13; relax to <2.14 to allow pydantic 2.13.x
+# constraint is "pydantic>=2.9.2,<2.13" — match on the pydantic line only
+sed -i '/pydantic/s/<2\.13/<2.14/' pyproject.toml
 
 %build
 set -ex
@@ -60,6 +63,10 @@ set -ex
 
 
 %changelog
+* Fri May 29 2026 Odilon Sousa <osousa@redhat.com> - 0.39.1-2
+- Relax pydantic upper bound to < 2.14 (upstream pins <2.13; pydantic 2.13.x in staging)
+- Patch pyproject.toml in %%prep to match relaxed bound
+
 * Thu May 14 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.39.1-1
 - Update to 0.39.1
 - Update Requires to match 0.39.1: relax packaging to <=26.2, requests to <2.34, add multidict and pydantic


### PR DESCRIPTION
## Problem

`pulp-glue 0.39.1` upstream pins `pydantic<2.13,>=2.9.2`. `pydantic 2.13.4` is now in `pulpcore-nightly-staging`, causing staging repoclosure to fail ([nightly pipeline #1185](https://ci.theforeman.org/blue/organizations/jenkins/pulpcore-nightly-rpm-pipeline/detail/pulpcore-nightly-rpm-pipeline/1185/pipeline)):

```
package: python3.12-pulp-glue-0.39.1-1.el9.noarch
  unresolved deps (2):
    (python3.12dist(pydantic) < 2.13 with python3.12dist(pydantic) >= 2.9.2)
    python3.12-pydantic < 2.13
```

Neither `pulp-glue 0.39.1` nor `0.39.2` have relaxed this constraint upstream.

## Fix

- Bump `Release: 1 → 2`  
- Change `Requires: python3.12-pydantic < 2.13` → `< 2.14`
- Add `sed` in `%prep` to patch `pyproject.toml` so the wheel-generated metadata is also consistent:
  ```bash
  sed -i 's/pydantic<2\.13/pydantic<2.14/g' pyproject.toml
  ```

## Upstream

Issue filed to relax the bound in a future pulp-glue release: https://github.com/pulp/pulp-cli/issues/1407

## Test plan
- [ ] COPR scratch build passes
- [ ] repoclosure passes (no more `pydantic < 2.13` conflict against staging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)