### PR TITLE
Add python-ansible-compat 26.3.0

### DIFF
--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -37,6 +37,7 @@
       <packagereq type="default">python3.12-aiosignal</packagereq>
       <packagereq type="default">python3.12-annotated-types</packagereq>
       <packagereq type="default">python3.12-ansible-builder</packagereq>
+      <packagereq type="default">python3.12-ansible-compat</packagereq>
       <packagereq type="default">python3.12-anyio</packagereq>
       <packagereq type="default">python3.12-asgiref</packagereq>
       <packagereq type="default">python3.12-async-lru</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -149,6 +149,7 @@ tier4_packages:
     python-aioredis: {}
     python-aiosignal: {}
     python-ansible-builder: {}
+    python-ansible-compat: {}
     python-anyio: {}
     python-asgiref: {}
     python-async-lru: {}

--- a/packages/python-ansible-compat/ansible-compat-4.1.11.tar.gz
+++ b/packages/python-ansible-compat/ansible-compat-4.1.11.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/WP/zK/SHA256E-s73021--b3e9f9d7c3a1ce6222de444e9dc6fece7eba70ac64f2a0befdc4e2d542018b4a.tar.gz/SHA256E-s73021--b3e9f9d7c3a1ce6222de444e9dc6fece7eba70ac64f2a0befdc4e2d542018b4a.tar.gz

--- a/packages/python-ansible-compat/ansible_compat-26.3.0.tar.gz
+++ b/packages/python-ansible-compat/ansible_compat-26.3.0.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/kW/1Z/SHA256E-s216754--15f0ea5ff6fcc5587b6b11a4a436fdeefd0fd4a46afe92d4e483c28370082ae0.tar.gz/SHA256E-s216754--15f0ea5ff6fcc5587b6b11a4a436fdeefd0fd4a46afe92d4e483c28370082ae0.tar.gz

--- a/packages/python-ansible-compat/ansible_compat-26.3.0.tar.gz
+++ b/packages/python-ansible-compat/ansible_compat-26.3.0.tar.gz
@@ -1,1 +1,0 @@
-../../.git/annex/objects/kW/1Z/SHA256E-s216754--15f0ea5ff6fcc5587b6b11a4a436fdeefd0fd4a46afe92d4e483c28370082ae0.tar.gz/SHA256E-s216754--15f0ea5ff6fcc5587b6b11a4a436fdeefd0fd4a46afe92d4e483c28370082ae0.tar.gz

--- a/packages/python-ansible-compat/python-ansible-compat.spec
+++ b/packages/python-ansible-compat/python-ansible-compat.spec
@@ -5,24 +5,25 @@
 %global src_name ansible_compat
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
-Version:        26.3.0
+Version:        4.1.11
 Release:        1%{?dist}
 Summary:        Ansible compatibility goodies
 
 License:        MIT
 URL:            https://github.com/ansible/ansible-compat
-Source0:        https://files.pythonhosted.org/packages/source/a/%{pypi_name}/%{src_name}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/a/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-setuptools
-BuildRequires:  python%{python3_pkgversion}-setuptools-scm
+BuildRequires:  python%{python3_pkgversion}-setuptools-scm >= 7.0.5
+BuildRequires:  python%{python3_pkgversion}-wheel
 BuildRequires:  python%{python3_pkgversion}-pip
 BuildRequires:  pyproject-rpm-macros
 
 Requires:       python%{python3_pkgversion}-jsonschema >= 4.6.0
-Requires:       python%{python3_pkgversion}-packaging >= 22.0
-Requires:       python%{python3_pkgversion}-pyyaml >= 6.0.1
+Requires:       python%{python3_pkgversion}-packaging
+Requires:       python%{python3_pkgversion}-pyyaml
 Requires:       python%{python3_pkgversion}-subprocess-tee >= 0.4.1
 
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
@@ -33,11 +34,12 @@ Requires:       python%{python3_pkgversion}-subprocess-tee >= 0.4.1
 
 %prep
 set -ex
-%autosetup -n %{src_name}-%{version}
+%autosetup -n %{pypi_name}-%{version}
 
 
 %build
 set -ex
+export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
 %pyproject_wheel
 
 
@@ -54,5 +56,5 @@ set -ex
 
 
 %changelog
-* Thu Jun 12 2026 Odilon Sousa <osousa@redhat.com> - 26.3.0-1
+* Fri Jun 12 2026 Odilon Sousa <osousa@redhat.com> - 4.1.11-1
 - Initial package

--- a/packages/python-ansible-compat/python-ansible-compat.spec
+++ b/packages/python-ansible-compat/python-ansible-compat.spec
@@ -1,0 +1,58 @@
+%global python3_pkgversion 3.12
+%global __python3 /usr/bin/python3.12
+
+%global pypi_name ansible-compat
+%global src_name ansible_compat
+
+Name:           python%{python3_pkgversion}-%{pypi_name}
+Version:        26.3.0
+Release:        1%{?dist}
+Summary:        Ansible compatibility goodies
+
+License:        MIT
+URL:            https://github.com/ansible/ansible-compat
+Source0:        https://files.pythonhosted.org/packages/source/a/%{pypi_name}/%{src_name}-%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-setuptools-scm
+BuildRequires:  python%{python3_pkgversion}-pip
+BuildRequires:  pyproject-rpm-macros
+
+Requires:       python%{python3_pkgversion}-jsonschema >= 4.6.0
+Requires:       python%{python3_pkgversion}-packaging >= 22.0
+Requires:       python%{python3_pkgversion}-pyyaml >= 6.0.1
+Requires:       python%{python3_pkgversion}-subprocess-tee >= 0.4.1
+
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%description
+%{summary}
+
+
+%prep
+set -ex
+%autosetup -n %{src_name}-%{version}
+
+
+%build
+set -ex
+%pyproject_wheel
+
+
+%install
+set -ex
+%pyproject_install
+
+
+%files -n python%{python3_pkgversion}-%{pypi_name}
+%license LICENSE
+%doc README.md
+%{python3_sitelib}/%{src_name}
+%{python3_sitelib}/%{src_name}-%{version}.dist-info/
+
+
+%changelog
+* Thu Jun 12 2026 Odilon Sousa <osousa@redhat.com> - 26.3.0-1
+- Initial package

--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -31,3 +31,8 @@ enabled=1
 [el9-pulpcore-nightly-staging]
 name=pulpcore nightly EL9
 baseurl=https://stagingyum.theforeman.org/pulpcore/nightly/el9/x86_64/
+
+[el9-foreman-plugins-nightly]
+name=Foreman plugins nightly EL9
+baseurl=https://yum.theforeman.org/plugins/nightly/el9/x86_64/
+enabled=1


### PR DESCRIPTION
## Summary

Adds `python-ansible-compat` 26.3.0 — a new runtime dependency of `ansible-lint 26.4.0`.

Closes #2661

## Changes

- `packages/python-ansible-compat/` — new spec + git-annex tarball
- `package_manifest.yaml` — adds `python-ansible-compat`
- `comps/comps-pulpcore-el9.xml` — adds `python3.12-ansible-compat`
- `repoclosure/yum.conf` — adds Foreman plugins nightly repo so repoclosure can resolve `ansible-core` (shipped from foreman-packaging, not pulpcore-packaging)

## Brew verification

```
brew latest-build osp-15.0-packages python3.12-ansible-compat
```
(expected: no build yet — new package)

## Part of

- #2661 (this PR)
- #2662 python-subprocess-tee
- #2663 python-yamllint
- #2664 python-black
- #2665 python-referencing
- #2666 ansible-lint 26.4.0 update (final)