### PR TITLE
Add python-subprocess-tee 0.4.2

### DIFF
--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -317,6 +317,7 @@
       <packagereq type="default">python3.12-solv</packagereq>
       <packagereq type="default">python3.12-solv</packagereq>
       <packagereq type="default">python3.12-soupsieve</packagereq>
+      <packagereq type="default">python3.12-subprocess-tee</packagereq>
       <packagereq type="default">python3.12-sqlparse</packagereq>
       <packagereq type="default">python3.12-tablib</packagereq>
       <packagereq type="default">python3.12-tenacity</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -283,6 +283,7 @@ tier4_packages:
     python-social-auth-core: {}
     python-socks: {}
     python-soupsieve: {}
+    python-subprocess-tee: {}
     python-tenacity: {}
     python-wcmatch: {}
     python-iniparse: {}

--- a/packages/python-subprocess-tee/python-subprocess-tee.spec
+++ b/packages/python-subprocess-tee/python-subprocess-tee.spec
@@ -1,0 +1,54 @@
+%global python3_pkgversion 3.12
+%global __python3 /usr/bin/python3.12
+
+%global pypi_name subprocess-tee
+%global src_name subprocess_tee
+
+Name:           python%{python3_pkgversion}-%{pypi_name}
+Version:        0.4.2
+Release:        1%{?dist}
+Summary:        A subprocess.run alternative that also allows capturing combined stdout/stderr
+
+License:        MIT
+URL:            https://github.com/pycontribs/subprocess-tee
+Source0:        https://files.pythonhosted.org/packages/source/s/%{pypi_name}/%{src_name}-%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-setuptools-scm >= 7.0.0
+BuildRequires:  python%{python3_pkgversion}-wheel
+BuildRequires:  python%{python3_pkgversion}-pip
+BuildRequires:  pyproject-rpm-macros
+
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%description
+%{summary}
+
+
+%prep
+set -ex
+%autosetup -n %{src_name}-%{version}
+
+
+%build
+set -ex
+export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
+%pyproject_wheel
+
+
+%install
+set -ex
+%pyproject_install
+
+
+%files -n python%{python3_pkgversion}-%{pypi_name}
+%license LICENSE
+%{python3_sitelib}/%{src_name}
+%{python3_sitelib}/%{src_name}-%{version}.dist-info/
+
+
+%changelog
+* Fri Jun 12 2026 Odilon Sousa <osousa@redhat.com> - 0.4.2-1
+- Initial package

--- a/packages/python-subprocess-tee/subprocess_tee-0.4.2.tar.gz
+++ b/packages/python-subprocess-tee/subprocess_tee-0.4.2.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/Vw/Gq/SHA256E-s14951--91b2b4da3aae9a7088d84acaf2ea0abee3f4fd9c0d2eae69a9b9122a71476590.tar.gz/SHA256E-s14951--91b2b4da3aae9a7088d84acaf2ea0abee3f4fd9c0d2eae69a9b9122a71476590.tar.gz


### PR DESCRIPTION
## Summary

Adds `python-subprocess-tee` 0.4.2 — runtime dependency of `python-ansible-compat 4.1.11` and `ansible-lint 6.22.2`.

Closes #2662

## Changes

- `packages/python-subprocess-tee/` — spec + git-annex tarball
- `package_manifest.yaml` — adds `python-subprocess-tee`
- `comps/comps-pulpcore-el9.xml` — adds `python3.12-subprocess-tee`

## Notes

- No runtime dependencies
- `license = {text = "MIT"}` — already in old dict format, no PEP 639 patch needed
- `setuptools_scm` uses only `local_scheme` (no `version_file`), `SETUPTOOLS_SCM_PRETEND_VERSION` set for tarball builds

## Part of #2666 prerequisite chain

- #2702 ✅ python-ansible-compat 4.1.11
- **#2662 this PR** python-subprocess-tee 0.4.2
- python-yamllint 1.38.0
- python-black 24.10.0