### PR TITLE
Add python-black 24.10.0

### DIFF
--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -50,6 +50,8 @@
       <packagereq type="default">python3.12-azure-storage-common</packagereq>
       <packagereq type="default">python3.12-backoff</packagereq>
       <packagereq type="default">python3.12-backports-zstd</packagereq>
+      <packagereq type="default">python3.12-black</packagereq>
+      <packagereq type="default">python3.12-blackd</packagereq>
       <packagereq type="default">python3.12-bandersnatch</packagereq>
       <packagereq type="default">python3.12-beautifulsoup4</packagereq>
       <packagereq type="default">python3.12-bindep</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -162,6 +162,7 @@ tier4_packages:
     python-azure-storage-common: {}
     python-backoff: {}
     python-backports-zstd: {}
+    python-black: {}
     python-bandersnatch: {}
     python-beautifulsoup4: {}
     python-bindep: {}

--- a/packages/python-black/black-24.10.0.tar.gz
+++ b/packages/python-black/black-24.10.0.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/kq/vz/SHA256E-s645813--846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875.tar.gz/SHA256E-s645813--846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875.tar.gz

--- a/packages/python-black/python-black.spec
+++ b/packages/python-black/python-black.spec
@@ -1,0 +1,76 @@
+%global python3_pkgversion 3.12
+%global __python3 /usr/bin/python3.12
+
+%global pypi_name black
+
+Name:           python%{python3_pkgversion}-%{pypi_name}
+Version:        24.10.0
+Release:        1%{?dist}
+Summary:        The uncompromising code formatter
+
+License:        MIT
+URL:            https://github.com/psf/black
+Source0:        https://files.pythonhosted.org/packages/source/b/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-hatchling >= 1.20.0
+BuildRequires:  python%{python3_pkgversion}-hatch_vcs
+BuildRequires:  python%{python3_pkgversion}-hatch_fancy_pypi_readme
+BuildRequires:  python%{python3_pkgversion}-pip
+BuildRequires:  pyproject-rpm-macros
+
+Requires:       python%{python3_pkgversion}-click >= 8.0.0
+Requires:       python%{python3_pkgversion}-mypy-extensions >= 0.4.3
+Requires:       python%{python3_pkgversion}-packaging >= 22.0
+Requires:       python%{python3_pkgversion}-pathspec >= 0.9.0
+Requires:       python%{python3_pkgversion}-platformdirs >= 2
+
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%description
+%{summary}
+
+
+%package -n python%{python3_pkgversion}-blackd
+Summary:        Black HTTP server component
+Requires:       python%{python3_pkgversion}-%{pypi_name} = %{version}-%{release}
+Requires:       python%{python3_pkgversion}-aiohttp >= 3.10
+
+%description -n python%{python3_pkgversion}-blackd
+HTTP server for the Black code formatter.
+
+
+%prep
+set -ex
+%autosetup -n %{pypi_name}-%{version}
+
+
+%build
+set -ex
+%pyproject_wheel
+
+
+%install
+set -ex
+%pyproject_install
+
+
+%files -n python%{python3_pkgversion}-%{pypi_name}
+%license LICENSE
+%doc README.md
+%exclude %{_bindir}/black
+%{python3_sitelib}/%{pypi_name}
+%{python3_sitelib}/blib2to3
+%{python3_sitelib}/__pycache__/_black_version.*
+%{python3_sitelib}/_black_version.py
+%{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
+
+%files -n python%{python3_pkgversion}-blackd
+%exclude %{_bindir}/blackd
+%{python3_sitelib}/blackd
+
+
+%changelog
+* Fri Jun 12 2026 Odilon Sousa <osousa@redhat.com> - 24.10.0-1
+- Initial package


### PR DESCRIPTION
## Summary

Adds `python-black` 24.10.0 — runtime dependency of `ansible-lint 6.22.2` (issue #2664).

Closes #2664

## Changes

- `packages/python-black/` — spec + git-annex tarball
- `package_manifest.yaml` — adds `python-black`
- `comps/comps-pulpcore-el9.xml` — adds `python3.12-black`

## Notes

- `license = { text = "MIT" }` — already dict format, no PEP 639 patch needed
- hatchling + hatch-vcs build backend; `SETUPTOOLS_SCM_PRETEND_VERSION` set for tarball builds
- Three installed paths: `black/`, `blib2to3/`, `_black_version.py` (+ pycache glob)
- CLI scripts `black` and `blackd` excluded via `%exclude %{_bindir}/black[d]`
- Runtime deps for Python 3.12: click, mypy-extensions (PR #2705 ✅), packaging, pathspec, platformdirs
- tomli and typing-extensions are Python < 3.11 only — not needed for our 3.12 build

## Part of #2666 prerequisite chain

- ✅ python-ansible-compat 4.1.11
- ✅ python-subprocess-tee 0.4.2
- ✅ python-yamllint 1.38.0
- ✅ python-mypy-extensions 1.1.0
- **#2664 this PR** python-black 24.10.0
- ansible-lint 5.4.0 → 6.22.2 (#2666)