### PR TITLE
repoclosure: add Foreman plugins nightly repo to lookaside repos

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -64,6 +64,7 @@ repoclosures:
           - el9-baseos
           - el9-appstream
           - el9-crb
+          - el9-foreman-plugins-nightly
 
 buildroot_packages:
   hosts:


### PR DESCRIPTION
## Summary

Fixes the nightly repoclosure pipeline failure caused by `ansible-core` being unresolvable.

## Root cause

`ansible-core` is provided by `foreman-packaging`, not `pulpcore-packaging`. The `repoclosure/yum.conf` already defines `[el9-foreman-plugins-nightly]` (added alongside `python-ansible-compat`), but `obal`'s repoclosure role only enables repos that are listed in `repoclosure_lookaside_repos` — passing them as `--repo <id>` flags to `dnf repoclosure`. Without this `package_manifest.yaml` entry, the repo config exists but is never activated during the repoclosure run.

## Change

```yaml
repoclosure_lookaside_repos:
  el9:
    - el9-baseos
    - el9-appstream
    - el9-crb
    + el9-foreman-plugins-nightly   # provides ansible-core
```