### PR TITLE
Fix python-ansible-compat: strip ansible-core dep from pyproject.toml

### DIFF
--- a/packages/python-ansible-compat/python-ansible-compat.spec
+++ b/packages/python-ansible-compat/python-ansible-compat.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        4.1.11
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Ansible compatibility goodies
 
 License:        MIT
@@ -35,6 +35,9 @@ Requires:       python%{python3_pkgversion}-subprocess-tee >= 0.4.1
 %prep
 set -ex
 %autosetup -n %{pypi_name}-%{version}
+# ansible-core is provided by foreman-packaging; strip it so it is not
+# auto-generated as an RPM dep from the dist-info
+sed -i '/ansible-core/d' pyproject.toml
 
 
 %build
@@ -56,5 +59,9 @@ set -ex
 
 
 %changelog
+* Fri Jun 12 2026 Odilon Sousa <osousa@redhat.com> - 4.1.11-2
+- Strip ansible-core from pyproject.toml in %%prep so it is not emitted
+  as an RPM dep (ansible-core is provided by foreman-packaging)
+
 * Fri Jun 12 2026 Odilon Sousa <osousa@redhat.com> - 4.1.11-1
 - Initial package


### PR DESCRIPTION
## Summary

Fixes CI failure where `ansible-core` cannot be resolved because it is provided by `foreman-packaging`, not `pulpcore-packaging`.

## Root cause

`ansible-compat 4.1.11` lists `ansible-core>=2.12` in its `pyproject.toml` dependencies. The RPM auto-dep generator reads this from the installed dist-info and emits `python3.12dist(ansible-core) >= 2.12` as a hard `Requires`, which cannot be satisfied in the pulpcore CI environment.

## Fix

Strip `ansible-core` from `pyproject.toml` in `%prep` before the wheel is built — the same approach used by `python-galaxy-importer` for `setup.cfg`:

```spec
%prep
sed -i '/ansible-core/d' pyproject.toml
```

This prevents the dep from appearing in the dist-info so the auto-dep generator never sees it.