### PR TITLE
Fix package_manifest.yaml tier-ordering violation (EL10 rebuild prep)

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -133,6 +133,7 @@ tier3_packages:
     python-docutils: {}
     python-trove-classifiers: {}
     python-hatchling: {}
+    python-expandvars: {}
     python-frozenlist: {}
     python-pbr: {}
     python-fastjsonschema: {}
@@ -362,7 +363,6 @@ tier4_packages:
     python-google-resumable-media: {}
     python-rsa: {}
     python-cachetools: {}
-    python-expandvars: {}
     python-mailbits: {}
     python-aiohappyeyeballs: {}
     python-propcache: {}


### PR DESCRIPTION
## Summary

Moves `python-expandvars` from `tier4_packages` into `tier3_packages` (ahead of `python-frozenlist`, which `BuildRequires` it) to fix a real cross-tier ordering violation ahead of the EL10 from-scratch rebuild.

## Context

Auditing `package_manifest.yaml` for the EL10 rebuild found 4 packages whose tier placement doesn't match their `BuildRequires`. Checked each against RHEL9/RHEL10's own OS repos (BaseOS/AppStream/CRB) to determine which are real build blockers versus ones that bootstrap fine from the OS on a first pass:

| BuildRequires | Provided by RHEL9 OS repo? | Provided by RHEL10 OS repo? | Real blocker? |
|---|---|---|---|
| `python-expandvars` | No | No | **Yes** — fixed here |
| `python-flit-core` | Yes (CRB) | Yes (CRB, unversioned `python3-flit-core`) | No |
| `python-cffi` | Yes (AppStream) | Yes (BaseOS, unversioned `python3-cffi`) | No |

Only `python-expandvars` needed a manifest change. The other two flagged violations (`python-packaging`/`python-pyparsing` → `python-flit-core`, and `python-zstandard` → `python-cffi`) are left as-is — they bootstrap from the OS repos, and "fixing" them by moving `python-flit-core` earlier would introduce a genuine circular `BuildRequires` dependency instead: `pyproject-rpm-macros` (which is *not* OS-provided) needs `python-packaging`, and `python-flit-core` needs `pyproject-rpm-macros`, so `pyproject-rpm-macros → packaging → flit-core → pyproject-rpm-macros` has no valid linear order among just this project's own packages. It only works today because `packaging`/`flit-core` come from the OS rather than from each other's builds.

## Verification

Re-ran the cross-tier `BuildRequires` audit after this change — the `python-frozenlist`/`python-expandvars` violation is gone, and as a side effect this also correctly orders `python-yarl` and `python-propcache` (both `tier4_packages`, both `BuildRequires` `python-expandvars`) relative to their dependency.

Ref: theforeman/el10_rebuild#11