### PR TITLE
Bump python-tomli release for EL10 rebuild verification

### DIFF
--- a/packages/python-tomli/python-tomli.spec
+++ b/packages/python-tomli/python-tomli.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.0.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        A little TOML parser for Python
 
 License:        MIT
@@ -53,6 +53,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 24 2026 Odilon Sousa <osousa@redhat.com> - 2.0.1-7
+- Bump release for EL10 rebuild
+
 * Mon Mar 17 2025 Odilon Sousa <osousa@redhat.com> - 2.0.1-6
 - Rebuild against python 3.12
 


### PR DESCRIPTION
## Summary

Release-only bump for `python-tomli`, part of the Foundation tier wave in the EL10 rebuild (theforeman/el10_rebuild#12). No functional spec changes needed — this is a verification build to confirm the package builds cleanly against the new `rhel-10-x86_64` chroot (theforeman/pulpcore-packaging#2769).

Manually confirmed via scratch build before opening this PR: both `rhel-9-x86_64` and `rhel-10-x86_64` succeed.

Ref: theforeman/el10_rebuild#12