### PR TITLE
Bump python-pyyaml release for EL10 rebuild verification

### DIFF
--- a/packages/python-pyyaml/python-pyyaml.spec
+++ b/packages/python-pyyaml/python-pyyaml.spec
@@ -8,7 +8,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        6.0.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        YAML parser and emitter for Python
 
 License:        MIT
@@ -55,6 +55,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 24 2026 Odilon Sousa <osousa@redhat.com> - 6.0.3-2
+- Bump release for EL10 rebuild
+
 * Wed Oct 22 2025 Foreman Packaging Automation <packaging@theforeman.org> - 6.0.3-1
 - Update to 6.0.3
 


### PR DESCRIPTION
## Summary

Release-only bump for `python-pyyaml`, part of the Foundation tier wave in the EL10 rebuild (theforeman/el10_rebuild#12). No functional spec changes needed — this is a verification build to confirm the package builds cleanly against the new `rhel-10-x86_64` chroot (theforeman/pulpcore-packaging#2769).

Ref: theforeman/el10_rebuild#12