### PR TITLE
Bump python-packaging release for EL10 rebuild verification

### DIFF
--- a/packages/python-packaging/python-packaging.spec
+++ b/packages/python-packaging/python-packaging.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        26.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Core utilities for Python packages
 
 License:        BSD-2-Clause or Apache-2.0
@@ -53,6 +53,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 24 2026 Odilon Sousa <osousa@redhat.com> - 26.2-2
+- Bump release for EL10 rebuild
+
 * Wed May 27 2026 Foreman Packaging Automation <packaging@theforeman.org> - 26.2-1
 - Update to 26.2
 - Fix PEP 639 license field for flit-core compatibility


### PR DESCRIPTION
## Summary

Release-only bump for `python-packaging`, part of the Foundation tier wave in the EL10 rebuild (theforeman/el10_rebuild#12). No functional spec changes needed — this is a verification build to confirm the package builds cleanly against the new `rhel-10-x86_64` chroot (theforeman/pulpcore-packaging#2769).

Ref: theforeman/el10_rebuild#12