### PR TITLE
Bump python-pyparsing release for EL10 rebuild verification

### DIFF
--- a/packages/python-pyparsing/python-pyparsing.spec
+++ b/packages/python-pyparsing/python-pyparsing.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.3.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python parsing module
 
 License:        MIT License
@@ -49,6 +49,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Fri Jul 24 2026 Odilon Sousa <osousa@redhat.com> - 3.3.2-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.3.2-1
 - Update to 3.3.2
 


### PR DESCRIPTION
## Summary

Release-only bump for `python-pyparsing`, part of the Foundation tier wave in the EL10 rebuild (theforeman/el10_rebuild#12). No functional spec changes needed — this is a verification build to confirm the package builds cleanly against the new `rhel-10-x86_64` chroot (theforeman/pulpcore-packaging#2769).

Ref: theforeman/el10_rebuild#12