### PR TITLE
Bump python-setuptools-scm release for EL10 rebuild verification

### DIFF
--- a/packages/python-setuptools-scm/python-setuptools-scm.spec
+++ b/packages/python-setuptools-scm/python-setuptools-scm.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        7.1.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        the blessed package to manage your versions by scm tags
 
 License:        MIT
@@ -60,6 +60,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 24 2026 Odilon Sousa <osousa@redhat.com> - 7.1.0-6
+- Bump release for EL10 rebuild
+
 * Tue Mar 18 2025 Odilon Sousa <osousa@redhat.com> - 7.1.0-5
 - Rebuild against python3.12
 


### PR DESCRIPTION
## Summary

Release-only bump for `python-setuptools-scm`, part of the Foundation tier wave in the EL10 rebuild (theforeman/el10_rebuild#12). No functional spec changes needed — this is a verification build to confirm the package builds cleanly against the new `rhel-10-x86_64` chroot (theforeman/pulpcore-packaging#2769).

Ref: theforeman/el10_rebuild#12