### PR TITLE
Bump python-flit-core release for EL10 rebuild verification

### DIFF
--- a/packages/python-flit-core/python-flit-core.spec
+++ b/packages/python-flit-core/python-flit-core.spec
@@ -5,7 +5,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.12.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Distribution-building parts of Flit. See flit package for more information
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -54,6 +54,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Fri Jul 24 2026 Odilon Sousa <osousa@redhat.com> - 3.12.0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 30 2025 Foreman Packaging Automation <packaging@theforeman.org> - 3.12.0-1
 - Update to 3.12.0
 


### PR DESCRIPTION
Release-only bump for `python-flit-core`, part of the tier2 wave in the EL10 rebuild (theforeman/el10_rebuild#13). Verification build against the new `rhel-10-x86_64` chroot.

Ref: theforeman/el10_rebuild#13