### PR TITLE
Bump python-poetry_core release for EL10 rebuild verification

### DIFF
--- a/packages/python-poetry_core/python-poetry_core.spec
+++ b/packages/python-poetry_core/python-poetry_core.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.4.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Poetry PEP 517 Build Backend
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -47,6 +47,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Fri Jul 24 2026 Odilon Sousa <osousa@redhat.com> - 2.4.0-2
+- Bump release for EL10 rebuild
+
 * Wed May 06 2026 Odilon Sousa <osousa@redhat.com> - 2.4.0-1
 - Release python-poetry_core 2.4.0
 


### PR DESCRIPTION
Release-only bump for `python-poetry_core`, part of the tier2 wave in the EL10 rebuild (theforeman/el10_rebuild#13). Verification build against the new `rhel-10-x86_64` chroot.

Ref: theforeman/el10_rebuild#13