### PR TITLE
Bump python-typing-extensions release for EL10 rebuild verification

### DIFF
--- a/packages/python-typing-extensions/python-typing-extensions.spec
+++ b/packages/python-typing-extensions/python-typing-extensions.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        4.16.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Backported and Experimental Type Hints for Python 3
 
 License:        PSF
@@ -48,6 +48,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 24 2026 Odilon Sousa <osousa@redhat.com> - 4.16.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 4.16.0-1
 - Update to 4.16.0
 


### PR DESCRIPTION
Release-only bump for `python-typing-extensions`, part of the tier2 wave in the EL10 rebuild (theforeman/el10_rebuild#13). Verification build against the new `rhel-10-x86_64` chroot.

Ref: theforeman/el10_rebuild#13