### PR TITLE
Bump python-setuptools-rust release for EL10 rebuild verification

### DIFF
--- a/packages/python-setuptools-rust/python-setuptools-rust.spec
+++ b/packages/python-setuptools-rust/python-setuptools-rust.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.11.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Setuptools Rust extension plugin
 
 License:        MIT
@@ -54,6 +54,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 24 2026 Odilon Sousa <osousa@redhat.com> - 1.11.1-2
+- Bump release for EL10 rebuild
+
 * Tue Jun 10 2025 Odilon Sousa <osousa@redhat.com> - 1.11.1-1
 - Release python-setuptools-rust 1.11.1
 


### PR DESCRIPTION
Release-only bump for `python-setuptools-rust`, part of the tier2 wave in the EL10 rebuild (theforeman/el10_rebuild#13). Verification build against the new `rhel-10-x86_64` chroot.

Ref: theforeman/el10_rebuild#13