### PR TITLE
Bump python-pyproject-metadata release for EL10 rebuild verification

### DIFF
--- a/packages/python-pyproject-metadata/python-pyproject-metadata.spec
+++ b/packages/python-pyproject-metadata/python-pyproject-metadata.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.9.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Dataclass for PEP 621 metadata with support for core metadata generation
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -46,6 +46,9 @@ set -ex
 %{python3_sitelib}/%{pkg_name}-%{version}.dist-info/
 
 %changelog
+* Fri Jul 24 2026 Odilon Sousa <osousa@redhat.com> - 0.9.0-3
+- Bump release for EL10 rebuild
+
 * Tue Mar 18 2025 Odilon Sousa <osousa@redhat.com> - 0.9.0-2
 - Rebuild against python3.12
 


### PR DESCRIPTION
Release-only bump for `python-pyproject-metadata`, part of the tier2 wave in the EL10 rebuild (theforeman/el10_rebuild#13). Verification build against the new `rhel-10-x86_64` chroot.

Ref: theforeman/el10_rebuild#13