### PR TITLE
Bump python-meson-python release for EL10 rebuild verification

### DIFF
--- a/packages/python-meson-python/python-meson-python.spec
+++ b/packages/python-meson-python/python-meson-python.spec
@@ -8,7 +8,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.16.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Meson Python build backend (PEP 517)
 
 License:        MIT
@@ -60,6 +60,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 24 2026 Odilon Sousa <osousa@redhat.com> - 0.16.0-3
+- Bump release for EL10 rebuild
+
 * Fri Apr 04 2025 Odilon Sousa <osousa@redhat.com> - 0.16.0-2
 - Rebuild against python3.12
 


### PR DESCRIPTION
Release-only bump for `python-meson-python`, part of the tier2 wave in the EL10 rebuild (theforeman/el10_rebuild#13). Verification build against the new `rhel-10-x86_64` chroot.

Ref: theforeman/el10_rebuild#13