### PR TITLE
Bump python-uv-build release for EL10 rebuild verification

### DIFF
--- a/packages/python-uv-build/python-uv-build.spec
+++ b/packages/python-uv-build/python-uv-build.spec
@@ -8,7 +8,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.9.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        The uv build backend
 
 License:        MIT OR Apache-2.0
@@ -61,5 +61,8 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 0.9.7-2
+- Bump release for EL10 rebuild
+
 * Thu Apr 02 2026 Odilon Sousa <osousa@redhat.com> - 0.9.7-1
 - Initial package


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 2 (theforeman/el10_rebuild#13) — bump Release for python-uv-build to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64