### PR TITLE
Bump python-flit release for EL10 rebuild verification

### DIFF
--- a/packages/python-flit/python-flit.spec
+++ b/packages/python-flit/python-flit.spec
@@ -5,7 +5,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.12.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Distribution-building parts of Flit. See flit package for more information
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -55,6 +55,9 @@ set -ex
 %{_bindir}/flit
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 3.12.0-2
+- Bump release for EL10 rebuild
+
 * Sun May 04 2025 Foreman Packaging Automation <packaging@theforeman.org> - 3.12.0-1
 - Update to 3.12.0
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 1 (theforeman/el10_rebuild#14) — bump Release for python-flit to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [x] Jenkins/COPR CI green on rhel-9-x86_64
- [x] Jenkins/COPR CI green on rhel-10-x86_64