### PR TITLE
Bump python-calver release for EL10 rebuild verification

### DIFF
--- a/packages/python-calver/python-calver.spec
+++ b/packages/python-calver/python-calver.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2022.06.26
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Setuptools extension for CalVer package versions
 
 License:        None
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 2022.06.26-7
+- Bump release for EL10 rebuild
+
 * Tue Mar 18 2025 Odilon Sousa <osousa@redhat.com> - 2022.06.26-6
 - Rebuild against python3.12
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 1 (theforeman/el10_rebuild#14) — bump Release for python-calver to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [x] Jenkins/COPR CI green on rhel-9-x86_64
- [x] Jenkins/COPR CI green on rhel-10-x86_64