### PR TITLE
Bump python-docutils release for EL10 rebuild verification

### DIFF
--- a/packages/python-docutils/python-docutils.spec
+++ b/packages/python-docutils/python-docutils.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.23
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Docutils -- Python Documentation Utilities
 
 License:        Public Domain and BSD and Python and GPLv3+
@@ -65,6 +65,9 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 0.23-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.23-1
 - Update to 0.23
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 1 (theforeman/el10_rebuild#14) — bump Release for python-docutils to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64