### PR TITLE
Bump python-hatchling release for EL10 rebuild verification

### DIFF
--- a/packages/python-hatchling/python-hatchling.spec
+++ b/packages/python-hatchling/python-hatchling.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.29.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        This is the extensible, standards compliant build backend used by Hatch.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -56,6 +56,9 @@ set -ex
 %{_bindir}/%{pypi_name}
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 1.29.0-2
+- Bump release for EL10 rebuild
+
 * Mon Mar 30 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.29.0-1
 - Update to 1.29.0
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 1 (theforeman/el10_rebuild#14) — bump Release for python-hatchling to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [x] Jenkins/COPR CI green on rhel-9-x86_64
- [x] Jenkins/COPR CI green on rhel-10-x86_64