### PR TITLE
Bump python-expandvars release for EL10 rebuild verification

### DIFF
--- a/packages/python-expandvars/python-expandvars.spec
+++ b/packages/python-expandvars/python-expandvars.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.12.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Expand system variables Unix style
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -44,6 +44,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}.py
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 0.12.0-3
+- Bump release for EL10 rebuild
+
 * Wed Mar 19 2025 Odilon Sousa <osousa@redhat.com> - 0.12.0-2
 - Rebuild against python3.12
 


### PR DESCRIPTION
## Summary
- EL10 rebuild (theforeman/el10_rebuild#14) — python-expandvars moved into `tier3_packages` via #2771 (tier-ordering fix) but has never actually been built for el10 (its only COPR build is rhel-9-x86_64, from 2024). This PR verifies it builds on el10 before wave 2's python-frozenlist (which `BuildRequires` it) is opened.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64