### PR TITLE
Bump python-pbr release for EL10 rebuild verification

### DIFF
--- a/packages/python-pbr/python-pbr.spec
+++ b/packages/python-pbr/python-pbr.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        7.0.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python Build Reasonableness
 
 License:        None
@@ -54,6 +54,9 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 7.0.3-2
+- Bump release for EL10 rebuild
+
 * Wed Nov 19 2025 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.3-1
 - Update to 7.0.3
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 2 (theforeman/el10_rebuild#14) — bump Release for python-pbr to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64