### PR TITLE
Bump python-fastjsonschema release for EL10 rebuild verification

### DIFF
--- a/packages/python-fastjsonschema/python-fastjsonschema.spec
+++ b/packages/python-fastjsonschema/python-fastjsonschema.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.21.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Fast JSON schema validator for Python.
 
 License:        BSD 3-Clause "New" or "Revised" License
@@ -46,6 +46,9 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 2.21.2-2
+- Bump release for EL10 rebuild
+
 * Mon Mar 30 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.21.2-1
 - Update to 2.21.2
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 2 (theforeman/el10_rebuild#14) — bump Release for python-fastjsonschema to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64