### PR TITLE
Bump python-poetry_plugin_export release for EL10 rebuild verification

### DIFF
--- a/packages/python-poetry_plugin_export/python-poetry_plugin_export.spec
+++ b/packages/python-poetry_plugin_export/python-poetry_plugin_export.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.8.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Poetry plugin to export the dependencies to various formats
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -48,6 +48,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 1.8.0-3
+- Bump release for EL10 rebuild
+
 * Wed Mar 19 2025 Odilon Sousa <osousa@redhat.com> - 1.8.0-2
 - Rebuild against python3.12
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 2 (theforeman/el10_rebuild#14) — bump Release for python-poetry_plugin_export to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64