### PR TITLE
Bump python-jaraco-context release for EL10 rebuild verification

### DIFF
--- a/packages/python-jaraco-context/python-jaraco-context.spec
+++ b/packages/python-jaraco-context/python-jaraco-context.spec
@@ -5,7 +5,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        6.1.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Useful decorators and context managers
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -53,6 +53,9 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 6.1.2-2
+- Bump release for EL10 rebuild
+
 * Sun Mar 22 2026 Foreman Packaging Automation <packaging@theforeman.org> - 6.1.2-1
 - Update to 6.1.2
 - Patch pyproject.toml for RHEL9 pip compatibility (PEP 639 license, coherent.licensed)


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 2 (theforeman/el10_rebuild#14) — bump Release for python-jaraco-context to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64