### PR TITLE
Bump python-jaraco-functools release for EL10 rebuild verification

### DIFF
--- a/packages/python-jaraco-functools/python-jaraco-functools.spec
+++ b/packages/python-jaraco-functools/python-jaraco-functools.spec
@@ -5,7 +5,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        4.5.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Additional functools in the spirit of stdlib's functools.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -55,6 +55,9 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 4.5.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 4.5.0-1
 - Update to 4.5.0
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 2 (theforeman/el10_rebuild#14) — bump Release for python-jaraco-functools to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64