### PR TITLE
Bump python-pdm-backend release for EL10 rebuild verification

### DIFF
--- a/packages/python-pdm-backend/python-pdm-backend.spec
+++ b/packages/python-pdm-backend/python-pdm-backend.spec
@@ -10,7 +10,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.4.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        The build backend used by PDM that supports latest packaging standards.
 
 License:        MIT license
@@ -73,6 +73,9 @@ git config --global user.email "john@doe.com"
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 2.4.3-3
+- Bump release for EL10 rebuild
+
 * Wed Mar 19 2025 Odilon Sousa <osousa@redhat.com> - 2.4.3-2
 - Rebuild against python3.12
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 3 (theforeman/el10_rebuild#14) — bump Release for python-pdm-backend to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64