### PR TITLE
Bump python-pbs-installer release for EL10 rebuild verification

### DIFF
--- a/packages/python-pbs-installer/python-pbs-installer.spec
+++ b/packages/python-pbs-installer/python-pbs-installer.spec
@@ -10,7 +10,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        2026.6.10
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Installer for Python Build Standalone
 BuildArch:      noarch
 
@@ -74,6 +74,9 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 2026.6.10-2
+- Bump release for EL10 rebuild
+
 * Sun Jun 28 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2026.6.10-1
 - Update to 2026.6.10
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 3 (theforeman/el10_rebuild#14) — bump Release for python-pbs-installer to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

**Note:** This package's `BuildRequires: python3.12-pdm-backend` depends on python-pdm-backend from this same wave (#2812). If CI fails on el10 with a missing-package error before that PR merges, this just needs a retrigger (amend + force-push, no spec changes) once it lands.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64