### PR TITLE
Bump python-findpython release for EL10 rebuild verification

### DIFF
--- a/packages/python-findpython/python-findpython.spec
+++ b/packages/python-findpython/python-findpython.spec
@@ -9,7 +9,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.8.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A utility to find python versions on your system
 BuildArch:      noarch
 
@@ -51,6 +51,9 @@ set -ex
 %{_bindir}/%{pypi_name}
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 0.8.0-2
+- Bump release for EL10 rebuild
+
 * Wed May 06 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.8.0-1
 - Update to 0.8.0
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 3 (theforeman/el10_rebuild#14) — bump Release for python-findpython to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

**Note:** This package's `BuildRequires: python3.12-pdm-backend` depends on python-pdm-backend from this same wave (#2812). If CI fails on el10 with a missing-package error before that PR merges, this just needs a retrigger (amend + force-push, no spec changes) once it lands.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64