### PR TITLE
Bump python-dulwich release for EL10 rebuild verification

### DIFF
--- a/packages/python-dulwich/python-dulwich.spec
+++ b/packages/python-dulwich/python-dulwich.spec
@@ -8,7 +8,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.2.10
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python Git Library
 
 License:        Apachev2 or later or GPLv2
@@ -62,6 +62,9 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 1.2.10-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.2.10-1
 - Update to 1.2.10
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 3 (theforeman/el10_rebuild#14) — bump Release for python-dulwich to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64