### PR TITLE
Bump python-cachecontrol release for EL10 rebuild verification

### DIFF
--- a/packages/python-cachecontrol/python-cachecontrol.spec
+++ b/packages/python-cachecontrol/python-cachecontrol.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        0.14.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        httplib2 caching for requests
 
 License:        Apache-2.0
@@ -70,6 +70,9 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 0.14.4-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 01 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.14.4-1
 - Update to 0.14.4
 - Fix PEP 639 license field for RHEL 9 pip compatibility


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 3 (theforeman/el10_rebuild#14) — bump Release for python-cachecontrol to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64