### PR TITLE
Bump python-distro release for EL10 rebuild verification

### DIFF
--- a/packages/python-distro/python-distro.spec
+++ b/packages/python-distro/python-distro.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        %{pypi_version}
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        Distro - an OS platform information API
 
 License:        Apache License, Version 2.0
@@ -54,6 +54,9 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 1.7.0-8
+- Bump release for EL10 rebuild
+
 * Wed Apr 09 2025 Odilon Sousa <osousa@redhat.com> - 1.7.0-7
 - Add obsoletes for python3.11 package
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 3 (theforeman/el10_rebuild#14) — bump Release for python-distro to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64