### PR TITLE
Bump python-crashtest release for EL10 rebuild verification

### DIFF
--- a/packages/python-crashtest/python-crashtest.spec
+++ b/packages/python-crashtest/python-crashtest.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.4.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Manage Python errors with ease
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -43,6 +43,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 0.4.1-7
+- Bump release for EL10 rebuild
+
 * Fri Mar 21 2025 Odilon Sousa <osousa@redhat.com> - 0.4.1-6
 - Rebuild against python3.12
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 3 (theforeman/el10_rebuild#14) — bump Release for python-crashtest to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64