### PR TITLE
Fix package_manifest.yaml tier-ordering violation: python-filelock

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -131,6 +131,7 @@ tier3_packages:
     python-pbs-installer: {}
     python-findpython: {}
     python-dulwich: {}
+    python-filelock: {}
     python-cachecontrol: {}
     python-build: {}
     python-cleo: {}
@@ -219,7 +220,6 @@ tier4_packages:
     python-hyperlink: {}
     python-id: {}
     python-jmespath: {}
-    python-filelock: {}
     python-flake8: {}
     python-future: {}
     python-galaxy-importer: {}

--- a/packages/python-filelock/python-filelock.spec
+++ b/packages/python-filelock/python-filelock.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.29.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A platform independent file lock
 
 License:        Unlicense
@@ -46,6 +46,9 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 3.29.6-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.29.6-1
 - Update to 3.29.6
 


### PR DESCRIPTION
## Summary
- EL10 rebuild (theforeman/el10_rebuild#14) — python-cachecontrol (`tier3_packages`) pulls in python-filelock as a dynamic build dependency via `%pyproject_buildrequires -x filecache`, which the original #11/#2771 tier-ordering audit missed (it only scanned static `BuildRequires:` lines).
- python-filelock lived in `tier4_packages`, so a from-scratch EL10 build of tier3 fails: `No matching package to install: 'python3.12dist(filelock) >= 3.8'`. Confirmed not OS-provided on either RHEL9 or RHEL10 base/CRB repos.
- Two commits:
  1. Move `python-filelock` into `tier3_packages`, ahead of `python-cachecontrol` (same class of fix as #2771 for python-expandvars).
  2. Bump python-filelock's Release to actually verify it builds on el10 — it had never been built for el10 at all (only rhel-9-x86_64, from 2026-03), same pattern as #2801.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64