### PR TITLE
Fix package_manifest.yaml tier-ordering violation: python-msgpack

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -132,6 +132,7 @@ tier3_packages:
     python-findpython: {}
     python-dulwich: {}
     python-filelock: {}
+    python-msgpack: {}
     python-cachecontrol: {}
     python-build: {}
     python-cleo: {}
@@ -239,7 +240,6 @@ tier4_packages:
     python-jeepney: {}
     python-lxml: {}
     python-more-itertools: {}
-    python-msgpack: {}
     python-mypy-extensions: {}
     python-parsley: {}
     python-pexpect: {}

--- a/packages/python-msgpack/python-msgpack.spec
+++ b/packages/python-msgpack/python-msgpack.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.2.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        MessagePack serializer
 
 License:        Apache 2.0
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 1.2.1-2
+- Bump release for EL10 rebuild
+
 * Sun Jun 28 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.2.1-1
 - Update to 1.2.1
 


### PR DESCRIPTION
## Summary
- EL10 rebuild (theforeman/el10_rebuild#14) — python-cachecontrol (`tier3_packages`) has an unconditional `Requires-Dist (cachecontrol)` on msgpack (not gated by any `extra ==`, unlike filelock/redis), resolved dynamically at build time via `%pyproject_buildrequires`. Same blind spot class as #2822 (python-filelock), found on the same package.
- python-msgpack lived in `tier4_packages`, so a from-scratch EL10 build of tier3 fails: `Problem: nothing provides requested (python3.12dist(msgpack) < 2~~ with python3.12dist(msgpack) >= 0.5.2)`. Confirmed not OS-provided on either RHEL9 or RHEL10 base/CRB repos.
- Two commits, same pattern as #2822:
  1. Move `python-msgpack` into `tier3_packages`, ahead of `python-cachecontrol`.
  2. Bump python-msgpack's Release to actually verify it builds on el10 — it had never been built for el10 at all (only rhel-9-x86_64).

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64