### PR TITLE
Bump python-hatch_fancy_pypi_readme release for EL10 rebuild verification

### DIFF
--- a/packages/python-hatch_fancy_pypi_readme/python-hatch_fancy_pypi_readme.spec
+++ b/packages/python-hatch_fancy_pypi_readme/python-hatch_fancy_pypi_readme.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        23.1.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Fancy PyPI READMEs with Hatch
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -49,6 +49,9 @@ set -ex
 %{_bindir}/hatch-fancy-pypi-readme
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 23.1.0-5
+- Bump release for EL10 rebuild
+
 * Tue Mar 25 2025 Odilon Sousa <osousa@redhat.com> - 23.1.0-4
 - Rebuild against python3.12
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 4 (theforeman/el10_rebuild#14) — bump Release for python-hatch_fancy_pypi_readme to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [x] Jenkins/COPR CI green on rhel-9-x86_64
- [x] Jenkins/COPR CI green on rhel-10-x86_64