### PR TITLE
Bump python-pytz release for EL10 rebuild verification

### DIFF
--- a/packages/python-pytz/python-pytz.spec
+++ b/packages/python-pytz/python-pytz.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2022.2.1
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        World timezone definitions, modern and historical
 
 License:        MIT
@@ -47,6 +47,9 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 2022.2.1-8
+- Bump release for EL10 rebuild
+
 * Wed Mar 19 2025 Odilon Sousa <osousa@redhat.com> - 2022.2.1-7
 - Rebuild against python3.12
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 4 (theforeman/el10_rebuild#14) — bump Release for python-pytz to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [x] Jenkins/COPR CI green on rhel-9-x86_64
- [x] Jenkins/COPR CI green on rhel-10-x86_64