### PR TITLE
Bump python-sqlparse release for EL10 rebuild verification

### DIFF
--- a/packages/python-sqlparse/python-sqlparse.spec
+++ b/packages/python-sqlparse/python-sqlparse.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.5.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A non-validating SQL parser
 
 License:        BSD-3-Clause
@@ -19,7 +19,6 @@ BuildRequires:  python%{python3_pkgversion}-pip
 BuildRequires:  python%{python3_pkgversion}-hatch_fancy_pypi_readme
 BuildRequires:  python%{python3_pkgversion}-hatchling
 BuildRequires:  python%{python3_pkgversion}-tomli
-BuildRequires: /usr/bin/pathfix.py
 
 
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
@@ -34,7 +33,7 @@ Obsoletes:      python3.11-%{pypi_name} < %{version}-%{release}
 set -ex
 %autosetup -n %{pypi_name}-%{version}
 #Fix cli.py ambiguous python shebang
-pathfix.py -pni "%{__python3} %{py3_shbang_opts}" sqlparse/cli.py
+%py3_shebang_fix sqlparse/cli.py
 
 
 %build
@@ -53,6 +52,11 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 0.5.5-2
+- Bump release for EL10 rebuild
+- Switch to %%py3_shebang_fix instead of the standalone pathfix.py binary,
+  which isn't provided by any package on el10
+
 * Mon Jan 05 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.5.5-1
 - Update to 0.5.5
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 4 (theforeman/el10_rebuild#14) — bump Release for python-sqlparse to produce a real, verifiable build for both EL9 and EL10.
- Initial CI failed on el10 only: `No matching package to install: '/usr/bin/pathfix.py'`. This spec called the standalone `pathfix.py` binary directly (via a file-based `BuildRequires: /usr/bin/pathfix.py`) to fix an ambiguous shebang in `sqlparse/cli.py`. On el9 that binary is provided by the system's default `python3-devel` (3.9); no package on el10 provides it.
- Switched to the standard `%py3_shebang_fix` macro (already used elsewhere in this repo, e.g. createrepo_c.spec), which uses RPM's own bundled `/usr/lib/rpm/redhat/pathfix.py` instead of requiring a separate binary — works identically on both el9 and el10, no new BuildRequires needed. Dropped the now-unnecessary `BuildRequires: /usr/bin/pathfix.py`.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64