### PR TITLE
Bump python-scikit-build release for EL10 rebuild verification

### DIFF
--- a/packages/python-scikit-build/python-scikit-build.spec
+++ b/packages/python-scikit-build/python-scikit-build.spec
@@ -10,7 +10,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.18.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Improved build system generator for Python C/C++/Fortran/Cython extensions
 
 License:        MIT License
@@ -58,5 +58,8 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 0.18.1-2
+- Bump release for EL10 rebuild
+
 * Tue Jan 16 2024 Odilon Sousa <osousa@redhat.com> -  0.18.1-1
 - Initial package.


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 4 (theforeman/el10_rebuild#14) — bump Release for python-scikit-build to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

**Note:** This package's `BuildRequires: python3.12-hatch_fancy_pypi_readme` depends on python-hatch_fancy_pypi_readme from this same wave (#2824). If CI fails on el10 with a missing-package error before that PR merges, this just needs a retrigger (amend + force-push, no spec changes) once it lands.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64