### PR TITLE
Bump python-proto-plus release for EL10 rebuild verification

### DIFF
--- a/packages/python-proto-plus/python-proto-plus.spec
+++ b/packages/python-proto-plus/python-proto-plus.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.28.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Beautiful, Pythonic protocol buffers.
 
 License:        Apache 2.0
@@ -50,6 +50,9 @@ set -ex
 
 
 %changelog
+* Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 1.28.0-2
+- Bump release for EL10 rebuild
+
 * Sun May 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.28.0-1
 - Update to 1.28.0
 


### PR DESCRIPTION
## Summary
- EL10 rebuild wave 4 (theforeman/el10_rebuild#14) — bump Release for python-proto-plus to produce a real, verifiable build for both EL9 and EL10.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [x] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64