### PR TITLE
EL10 rebuild: ansible-lint, createrepo_c, python-aiodns, python-aiofiles, python-aiohttp, python-aiohttp-socks, python-aiohttp-xmlrpc

### DIFF
--- a/packages/ansible-lint/ansible-lint.spec
+++ b/packages/ansible-lint/ansible-lint.spec
@@ -6,7 +6,7 @@
 
 Name:           %{pypi_name}
 Version:        6.22.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Checks playbooks for practices and behaviour that could potentially be improved
 
 License:        GPLv3+
@@ -61,6 +61,9 @@ set -ex
 %{python3_sitelib}/ansible_lint-%{version}.dist-info/
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 6.22.2-2
+- Bump release for EL10 rebuild
+
 * Fri Jun 12 2026 Odilon Sousa <osousa@redhat.com> - 6.22.2-1
 - Update to 6.22.2
 - Update License to GPLv3+

--- a/packages/createrepo_c/createrepo_c.spec
+++ b/packages/createrepo_c/createrepo_c.spec
@@ -46,7 +46,7 @@
 Summary:        Creates a common metadata repository
 Name:           createrepo_c
 Version:        1.2.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPL-2.0-or-later
 URL:            https://github.com/rpm-software-management/createrepo_c
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
@@ -275,6 +275,9 @@ ln -sr %{buildroot}%{_bindir}/modifyrepo_c %{buildroot}%{_bindir}/modifyrepo
 %endif
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.2.1-3
+- Bump release for EL10 rebuild
+
 * Mon Apr 07 2025 Odilon Sousa <osousa@redhat.com> - 1.2.1-2
 - Add obsoletes for python3.11 package
 

--- a/packages/python-aiodns/python-aiodns.spec
+++ b/packages/python-aiodns/python-aiodns.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.6.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Simple DNS resolver for asyncio
 
 License:        MIT
@@ -48,6 +48,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 3.6.1-2
+- Bump release for EL10 rebuild
+
 * Wed Jan 21 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.6.1-1
 - Update to 3.6.1
 

--- a/packages/python-aiofiles/python-aiofiles.spec
+++ b/packages/python-aiofiles/python-aiofiles.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        25.1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        File support for asyncio
 
 License:        Apache 2.0
@@ -46,6 +46,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 25.1.0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 25.1.0-1
 - Update to 25.1.0
 

--- a/packages/python-aiohttp-socks/python-aiohttp-socks.spec
+++ b/packages/python-aiohttp-socks/python-aiohttp-socks.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.10.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Proxy connector for aiohttp
 
 License:        Apache 2
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 0.10.1-2
+- Bump release for EL10 rebuild
+
 * Sun Jun 22 2025 Foreman Packaging Automation <packaging@theforeman.org> - 0.10.1-1
 - Update to 0.10.1
 

--- a/packages/python-aiohttp-xmlrpc/python-aiohttp-xmlrpc.spec
+++ b/packages/python-aiohttp-xmlrpc/python-aiohttp-xmlrpc.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.5.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        aiohttp XML-RPC server handler and client
 
 License:        MIT
@@ -50,6 +50,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.5.0-8
+- Bump release for EL10 rebuild
+
 * Mon Mar 31 2025 Odilon Sousa <osousa@redhat.com> - 1.5.0-7
 - Rebuild against python3.12
 

--- a/packages/python-aiohttp/python-aiohttp.spec
+++ b/packages/python-aiohttp/python-aiohttp.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.13.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Async http client/server framework (asyncio)
 
 License:        Apache 2
@@ -60,6 +60,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 3.13.5-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 01 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.13.5-1
 - Update to 3.13.5
 


### PR DESCRIPTION
## Summary
- EL10 rebuild tier4 wave 1 (theforeman/el10_rebuild#15) — bump Release for 7 independent tier4 packages to produce real, verifiable builds for both EL9 and EL10.
- 7 packages, 1 commit per package, no functional spec changes — Release bump + changelog entry only.
- No intra-wave `BuildRequires` dependencies between these packages; all cross-dependencies resolve from already-merged tier1-tier3 packages.
- (postgresql-debversion and postgresql-evr were dropped from this wave — no longer used when installing pulp RPMs. libcomps was split out into its own PR — #2835 — since it needed real spec changes and closer review, not just a release bump.)

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64 for all 7 packages
- [ ] Jenkins/COPR CI green on rhel-10-x86_64 for all 7 packages