### PR TITLE
EL10 rebuild: python-azure-storage-blob, python-backoff, python-backports-zstd, python-black, python-bandersnatch, python-beautifulsoup4, python-bindep, python-boto3, python-botocore, python-bracex

### DIFF
--- a/packages/python-azure-storage-blob/python-azure-storage-blob.spec
+++ b/packages/python-azure-storage-blob/python-azure-storage-blob.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        12.30.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Microsoft Azure Blob Storage Client Library for Python
 
 License:        MIT License
@@ -55,6 +55,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 12.30.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 12.30.0-1
 - Update to 12.30.0
 - Update azure-core minimum requirement to >= 1.37.0

--- a/packages/python-backoff/python-backoff.spec
+++ b/packages/python-backoff/python-backoff.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.2.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Function decoration for backoff and retry
 
 License:        MIT
@@ -46,6 +46,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 2.2.1-7
+- Bump release for EL10 rebuild
+
 * Tue Apr 01 2025 Odilon Sousa <osousa@redhat.com> - 2.2.1-6
 - Rebuild against python3.12
 

--- a/packages/python-backports-zstd/python-backports-zstd.spec
+++ b/packages/python-backports-zstd/python-backports-zstd.spec
@@ -10,7 +10,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        1.3.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Backport of the Python 3.14 compression.zstd module
 
 License:        PSF-2.0
@@ -60,5 +60,8 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.3.0-2
+- Bump release for EL10 rebuild
+
 * Mon Mar 30 2026 Odilon Sousa <osousa@redhat.com> - 1.3.0-1
 - Initial package.

--- a/packages/python-bandersnatch/python-bandersnatch.spec
+++ b/packages/python-bandersnatch/python-bandersnatch.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        6.6.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Mirroring tool that implements the client (mirror) side of PEP 381
 
 License:        Academic Free License, version 3
@@ -61,6 +61,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 6.6.0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 6.6.0-1
 - Update to 6.6.0
 

--- a/packages/python-beautifulsoup4/python-beautifulsoup4.spec
+++ b/packages/python-beautifulsoup4/python-beautifulsoup4.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        4.15.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Screen-scraping library
 
 License:        MIT
@@ -49,6 +49,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 4.15.0-3
+- Bump release for EL10 rebuild
+
 * Fri Jun 12 2026 Odilon Sousa <osousa@redhat.com> - 4.15.0-2
 - Update soupsieve minimum to >= 1.6.1 (upstream 4.15.0 requires soupsieve >= 1.6.1)
 - Add typing-extensions >= 4.0.0 runtime dependency (new in upstream 4.15.0)

--- a/packages/python-bindep/python-bindep.spec
+++ b/packages/python-bindep/python-bindep.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.14.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Binary dependency utility
 
 License:        Apache License, Version 2.0
@@ -58,6 +58,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 2.14.0-2
+- Bump release for EL10 rebuild
+
 * Sun Mar 22 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.14.0-1
 - Update to 2.14.0
 

--- a/packages/python-black/python-black.spec
+++ b/packages/python-black/python-black.spec
@@ -5,7 +5,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        24.10.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        The uncompromising code formatter
 
 License:        MIT
@@ -72,5 +72,8 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 24.10.0-2
+- Bump release for EL10 rebuild
+
 * Fri Jun 12 2026 Odilon Sousa <osousa@redhat.com> - 24.10.0-1
 - Initial package

--- a/packages/python-boto3/python-boto3.spec
+++ b/packages/python-boto3/python-boto3.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.43.42
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        The AWS SDK for Python
 
 License:        Apache License 2.0
@@ -55,6 +55,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.43.42-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.43.42-1
 - Update to 1.43.42
 

--- a/packages/python-botocore/python-botocore.spec
+++ b/packages/python-botocore/python-botocore.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.43.42
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Low-level, data-driven core of boto 3
 
 License:        Apache License 2.0
@@ -61,6 +61,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.43.42-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.43.42-1
 - Update to 1.43.42
 

--- a/packages/python-bracex/python-bracex.spec
+++ b/packages/python-bracex/python-bracex.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Bash style brace expander
 
 License:        MIT License
@@ -46,6 +46,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 3.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.0-1
 - Update to 3.0
 


### PR DESCRIPTION
## Summary
- EL10 rebuild tier4 wave 3 (theforeman/el10_rebuild#15) — bump Release for 10 independent tier4 packages to produce real, verifiable builds for both EL9 and EL10.
- 10 packages, 1 commit per package, no functional spec changes — Release bump + changelog entry only.
- No intra-wave `BuildRequires` dependencies (checked via automated audit); also cross-checked against wave 4 (#2838, opened alongside this one) since both are open simultaneously — no dependencies in either direction.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64 for all 10 packages
- [ ] Jenkins/COPR CI green on rhel-10-x86_64 for all 10 packages