### PR TITLE
EL10 rebuild: python-brotli, python-certifi, python-chardet, python-charset-normalizer, python-click

### DIFF
--- a/packages/python-brotli/python-brotli.spec
+++ b/packages/python-brotli/python-brotli.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        1.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python bindings for the Brotli compression library
 
 License:        MIT
@@ -50,6 +50,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.2.0-2
+- Bump release for EL10 rebuild
+
 * Fri Jan 30 2026 Odilon Sousa <osousa@redhat.com> - 1.2.0-1
 - Release python-brotli 1.2.0
 

--- a/packages/python-certifi/python-certifi.spec
+++ b/packages/python-certifi/python-certifi.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2026.6.17
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python package for providing Mozilla's CA Bundle
 
 License:        MPL-2.0
@@ -62,6 +62,9 @@ diff --ignore-blank-lines /etc/pki/tls/certs/ca-bundle.crt contents
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 2026.6.17-2
+- Bump release for EL10 rebuild
+
 * Sun Jun 28 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2026.6.17-1
 - Update to 2026.6.17
 

--- a/packages/python-chardet/python-chardet.spec
+++ b/packages/python-chardet/python-chardet.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        5.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Universal encoding detector for Python 3
 
 License:        LGPL
@@ -47,6 +47,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 5.2.0-2
+- Bump release for EL10 rebuild
+
 * Thu Apr 03 2025 Odilon Sousa <osousa@redhat.com> - 5.2.0-1
 - Release python-chardet 5.2.0
 

--- a/packages/python-charset-normalizer/python-charset-normalizer.spec
+++ b/packages/python-charset-normalizer/python-charset-normalizer.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.4.9
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet
 
 License:        MIT
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 3.4.9-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.4.9-1
 - Update to 3.4.9
 

--- a/packages/python-click/python-click.spec
+++ b/packages/python-click/python-click.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        8.3.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Composable command line interface toolkit
 
 License:        BSD-3-Clause
@@ -55,6 +55,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 8.3.3-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 8.3.3-1
 - Update to 8.3.3
 - Fix pyproject.toml for RHEL 9 flit_core: convert PEP 639 license string to dict format


### PR DESCRIPTION
## Summary
- EL10 rebuild tier4 wave 4 (theforeman/el10_rebuild#15) — bump Release for 5 independent tier4 packages to produce real, verifiable builds for both EL9 and EL10.
- 5 packages, 1 commit per package, no functional spec changes — Release bump + changelog entry only.
- Dropped 5 packages originally in this wave — python-click-shell, python-colorama, python-commonmark, python-contextlib2, python-dataclasses — all hardcode `%global python3_pkgversion 3.11`, which fails on el10 (`No matching package to install: 'python3.11-devel'` — RHEL10 only has python3.9/3.12, not 3.11). Tracked for proper cleanup (bump to 3.12, add Obsoletes, remove genuinely-dead ones from package_manifest.yaml/comps.xml) in a dedicated follow-up issue rather than fixed here.
- No intra-wave `BuildRequires` dependencies among the remaining 5 (checked via automated audit); also cross-checked against wave 3 (#2837) since both were open simultaneously — no dependencies in either direction.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64 for all 5 packages
- [ ] Jenkins/COPR CI green on rhel-10-x86_64 for all 5 packages