### PR TITLE
EL10 rebuild: python-dateutil, python-debian, python-defusedxml, python-deprecated, python-diff-match-patch, python-django, python-django-filter

### DIFF
--- a/packages/python-dateutil/python-dateutil.spec
+++ b/packages/python-dateutil/python-dateutil.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        2.8.2
-Release:        8%{?dist}
+Release:        9%{?dist}
 Summary:        Extensions to the standard Python datetime module
 
 License:        Dual License
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 2.8.2-9
+- Bump release for EL10 rebuild
+
 * Tue Apr 01 2025 Odilon Sousa <osousa@redhat.com> - 2.8.2-8
 - Rebuild against python3.12
 

--- a/packages/python-debian/python-debian.spec
+++ b/packages/python-debian/python-debian.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        0.1.49
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Debian package related modules
 
 License:        GPL-2+
@@ -54,6 +54,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 0.1.49-3
+- Bump release for EL10 rebuild
+
 * Thu Apr 03 2025 Odilon Sousa <osousa@redhat.com> - 0.1.49-2
 - Rebuild against python3.12
 

--- a/packages/python-defusedxml/python-defusedxml.spec
+++ b/packages/python-defusedxml/python-defusedxml.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.7.1
-Release:        8%{?dist}
+Release:        9%{?dist}
 Summary:        XML bomb protection for Python stdlib modules
 
 License:        PSFL
@@ -49,6 +49,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 0.7.1-9
+- Bump release for EL10 rebuild
+
 * Wed Apr 02 2025 Odilon Sousa <osousa@redhat.com> - 0.7.1-8
 - Rebuild against python3.12
 

--- a/packages/python-deprecated/python-deprecated.spec
+++ b/packages/python-deprecated/python-deprecated.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        1.2.18
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Python @deprecated decorator to deprecate old python classes, functions or methods
 
 License:        MIT
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.2.18-3
+- Bump release for EL10 rebuild
+
 * Wed Apr 02 2025 Odilon Sousa <osousa@redhat.com> - 1.2.18-2
 - Rebuild against python3.12
 

--- a/packages/python-django-filter/python-django-filter.spec
+++ b/packages/python-django-filter/python-django-filter.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        25.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Django-filter is a reusable Django application for allowing users to filter querysets dynamically
 
 License:        BSD
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 25.1-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 23 2025 Foreman Packaging Automation <packaging@theforeman.org> - 25.1-1
 - Update to 25.1
 

--- a/packages/python-django/python-django.spec
+++ b/packages/python-django/python-django.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        4.2.30
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A high-level Python web framework that encourages rapid development and clean, pragmatic design
 
 License:        BSD-3-Clause
@@ -67,6 +67,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 4.2.30-2
+- Bump release for EL10 rebuild
+
 * Tue Apr 07 2026 Foreman Packaging Automation <packaging@theforeman.org> - 4.2.30-1
 - Update to 4.2.30
 


### PR DESCRIPTION
## Summary
- EL10 rebuild tier4 wave 5 (theforeman/el10_rebuild#15) — bump Release for 7 independent tier4 packages to produce real, verifiable builds for both EL9 and EL10.
- 7 packages, 1 commit per package, no functional spec changes — Release bump + changelog entry only.
- `python-django-guid` split out into its own PR (#2848) — it's the only package in this wave that `BuildRequires: python3.12-poetry`, which has turned into a deep chain of tier gaps (#2841, #2842, #2845, #2846, #2847, and counting). No reason to keep blocking the other 7 clean packages on that chain.
- No intra-wave `BuildRequires` dependencies among the remaining 7 (checked via automated audit).

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64 for all 7 packages
- [ ] Jenkins/COPR CI green on rhel-10-x86_64 for all 7 packages