### PR TITLE
EL10 rebuild: python-django-import-export, python-django-lifecycle, python-django-readonly-field, python-djangorestframework, python-djangorestframework-queryfields, python-dnspython, python-drf-access-policy, python-drf-nested-routers, python-drf-spectacular, python-dynaconf

### DIFF
--- a/packages/python-django-import-export/python-django-import-export.spec
+++ b/packages/python-django-import-export/python-django-import-export.spec
@@ -8,7 +8,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        4.4.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Django application and library for importing and exporting data with included admin integration
 
 License:        BSD License
@@ -61,6 +61,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 4.4.1-2
+- Bump release for EL10 rebuild
+
 * Wed May 06 2026 Foreman Packaging Automation <packaging@theforeman.org> - 4.4.1-1
 - Update to 4.4.1
 

--- a/packages/python-django-lifecycle/python-django-lifecycle.spec
+++ b/packages/python-django-lifecycle/python-django-lifecycle.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.2.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Declarative model lifecycle hooks
 
 License:        MIT
@@ -56,6 +56,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.2.7-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.2.7-1
 - Update to 1.2.7
 

--- a/packages/python-django-readonly-field/python-django-readonly-field.spec
+++ b/packages/python-django-readonly-field/python-django-readonly-field.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.1.2
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Make Django model fields readonly
 
 License:        MIT
@@ -59,6 +59,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.1.2-7
+- Bump release for EL10 rebuild
+
 * Mon Apr 07 2025 Odilon Sousa <osousa@redhat.com> - 1.1.2-6
 - Add obsoletes for python3.11 package
 

--- a/packages/python-djangorestframework-queryfields/python-djangorestframework-queryfields.spec
+++ b/packages/python-djangorestframework-queryfields/python-djangorestframework-queryfields.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.1.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Serialize a partial subset of fields in the API
 
 License:        MIT
@@ -50,6 +50,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.1.0-4
+- Bump release for EL10 rebuild
+
 * Mon Apr 07 2025 Odilon Sousa <osousa@redhat.com> - 1.1.0-3
 - Add obsoletes for python3.11 package
 

--- a/packages/python-djangorestframework/python-djangorestframework.spec
+++ b/packages/python-djangorestframework/python-djangorestframework.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.16.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Web APIs for Django, made easy
 
 License:        BSD
@@ -55,6 +55,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 3.16.1-2
+- Bump release for EL10 rebuild
+
 * Wed Oct 22 2025 Foreman Packaging Automation <packaging@theforeman.org> - 3.16.1-1
 - Update to 3.16.1
 

--- a/packages/python-dnspython/python-dnspython.spec
+++ b/packages/python-dnspython/python-dnspython.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.8.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        DNS toolkit for Python
 
 License:        ISC
@@ -50,5 +50,8 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 2.8.0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Odilon Sousa <osousa@redhat.com> - 2.8.0-1
 - Initial package.

--- a/packages/python-drf-access-policy/python-drf-access-policy.spec
+++ b/packages/python-drf-access-policy/python-drf-access-policy.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.5.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Declarative access policies/permissions modeled after AWS' IAM policies
 
 License:        MIT
@@ -53,6 +53,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.5.0-4
+- Bump release for EL10 rebuild
+
 * Tue Apr 08 2025 Odilon Sousa <osousa@redhat.com> - 1.5.0-3
 - Add obsoletes for python3.11 package
 

--- a/packages/python-drf-nested-routers/python-drf-nested-routers.spec
+++ b/packages/python-drf-nested-routers/python-drf-nested-routers.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.95.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Nested resources for the Django Rest Framework
 
 License:        Apache
@@ -58,6 +58,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 0.95.0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.95.0-1
 - Update to 0.95.0
 

--- a/packages/python-drf-spectacular/python-drf-spectacular.spec
+++ b/packages/python-drf-spectacular/python-drf-spectacular.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.29.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Sane and flexible OpenAPI 3 schema generation for Django REST framework
 
 License:        BSD
@@ -63,6 +63,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 0.29.0-2
+- Bump release for EL10 rebuild
+
 * Sun Mar 22 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.29.0-1
 - Update to 0.29.0
 - Fix Source0 tarball name (drf_spectacular underscore)

--- a/packages/python-dynaconf/python-dynaconf.spec
+++ b/packages/python-dynaconf/python-dynaconf.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.2.13
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        The dynamic configurator for your Python Project
 
 License:        MIT
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 3.2.13-2
+- Bump release for EL10 rebuild
+
 * Wed Mar 18 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.2.13-1
 - Update to 3.2.13
 


### PR DESCRIPTION
## Summary
- EL10 rebuild tier4 wave 6 (theforeman/el10_rebuild#15) — bump Release for 10 independent tier4 packages to produce real, verifiable builds for both EL9 and EL10.
- 10 packages, 1 commit per package, no functional spec changes — Release bump + changelog entry only.
- No intra-wave `BuildRequires` dependencies, no `python3_pkgversion` hardcoding issues (checked via automated audit); also cross-checked against wave 5 (#2839, opened alongside this one) since both are open simultaneously — no dependencies in either direction.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64 for all 10 packages
- [ ] Jenkins/COPR CI green on rhel-10-x86_64 for all 10 packages