### PR TITLE
EL10 rebuild: python-pkginfo, python-platformdirs, python-pyproject_hooks, python-requests-toolbelt, python-shellingham, python-tomlkit, python-virtualenv

### DIFF
--- a/packages/python-pkginfo/python-pkginfo.spec
+++ b/packages/python-pkginfo/python-pkginfo.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.12.1.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Query metadatdata from sdists / bdists / installed packages
 
 License:        MIT
@@ -54,6 +54,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.12.1.2-4
+- Bump release for EL10 rebuild
+
 * Wed Apr 09 2025 Odilon Sousa <osousa@redhat.com> - 1.12.1.2-3
 - Add obsoletes for python3.11 package
 

--- a/packages/python-platformdirs/python-platformdirs.spec
+++ b/packages/python-platformdirs/python-platformdirs.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        4.10.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A small Python module for determining appropriate platform-specific dirs, e
 
 License:        MIT
@@ -45,6 +45,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 4.10.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 4.10.0-1
 - Update to 4.10.0
 

--- a/packages/python-pyproject_hooks/python-pyproject_hooks.spec
+++ b/packages/python-pyproject_hooks/python-pyproject_hooks.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.2.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Wrappers to call pyproject.toml-based build backend hooks.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -43,6 +43,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.2.0-3
+- Bump release for EL10 rebuild
+
 * Tue Mar 25 2025 Odilon Sousa <osousa@redhat.com> - 1.2.0-2
 - Rebuild against python3.12
 

--- a/packages/python-requests-toolbelt/python-requests-toolbelt.spec
+++ b/packages/python-requests-toolbelt/python-requests-toolbelt.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.0.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        A utility belt for advanced users of python-requests
 
 License:        Apache 2.0
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.0.0-7
+- Bump release for EL10 rebuild
+
 * Mon Mar 24 2025 Odilon Sousa <osousa@redhat.com> - 1.0.0-6
 - Rebuild against python3.12
 

--- a/packages/python-shellingham/python-shellingham.spec
+++ b/packages/python-shellingham/python-shellingham.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.5.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Tool to Detect Surrounding Shell
 
 License:        ISC License
@@ -49,6 +49,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.5.4-3
+- Bump release for EL10 rebuild
+
 * Tue Mar 25 2025 Odilon Sousa <osousa@redhat.com> - 1.5.4-2
 - Rebuild against python3.12
 

--- a/packages/python-tomlkit/python-tomlkit.spec
+++ b/packages/python-tomlkit/python-tomlkit.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.15.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Style preserving TOML library
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -44,6 +44,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 0.15.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.15.0-1
 - Update to 0.15.0
 

--- a/packages/python-virtualenv/python-virtualenv.spec
+++ b/packages/python-virtualenv/python-virtualenv.spec
@@ -5,7 +5,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        21.6.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A tool for creating isolated virtual python environments.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -58,6 +58,9 @@ set -ex
 %{_bindir}/%{pypi_name}
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 21.6.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 21.6.0-1
 - Update to 21.6.0
 


### PR DESCRIPTION
## Summary
- EL10 rebuild (theforeman/el10_rebuild#15) — python-poetry (tier3, already merged for el10) has hard `Requires` on these 7 packages, all still in later tier4 waves (10, 11, 16, 17, 19) and never built for el10.
- Any package that `BuildRequires: python3.12-poetry` fails to even set up its el10 buildroot as a result — found via python-django-guid (wave 5, #2839): `nothing provides (python3.12dist(pkginfo) ...)` and 6 similar errors for the other packages here.
- Bundling all 7 into one prerequisite PR ahead of their scheduled waves, same pattern as the earlier python-expandvars/python-filelock/python-msgpack tier gaps. No interdependencies among these 7 (checked); all already use `python3_pkgversion 3.12`.
- 7 packages, 1 commit per package, no functional spec changes — Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64 for all 7 packages
- [ ] Jenkins/COPR CI green on rhel-10-x86_64 for all 7 packages