### PR TITLE
EL10 rebuild: python-discovery, python-distlib

### DIFF
--- a/packages/python-discovery/python-discovery.spec
+++ b/packages/python-discovery/python-discovery.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        1.4.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A utility to discover Python interpreters
 
 License:        MIT
@@ -53,6 +53,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 1.4.3-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.4.3-1
 - Update to 1.4.3
 

--- a/packages/python-distlib/python-distlib.spec
+++ b/packages/python-distlib/python-distlib.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.4.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Distlib is a library which implements low-level functions that relate to packaging and distribution of Python software.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -49,6 +49,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 0.4.3-2
+- Bump release for EL10 rebuild
+
 * Sun Jun 28 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.4.3-1
 - Update to 0.4.3
 


### PR DESCRIPTION
## Summary
- EL10 rebuild (theforeman/el10_rebuild#15) — python-virtualenv (just merged, #2841) has hard `Requires` on `python-discovery >= 1.4.2` and `python-distlib >= 0.3.7`, neither built for el10 yet.
- Both packages happened to be bundled inside wave 5 (#2839, alongside python-django-guid, which needs them transitively via `python-poetry` -> `python-virtualenv`) — since they were unmerged commits in the same open PR, virtualenv couldn't be installed to build django-guid.
- Split out into their own small prerequisite PR so they land before wave 5 retriggers. No further gaps: `python-discovery` only needs `python-filelock`/`python-platformdirs` (both already built), `python-distlib` has no extra Requires.
- 2 packages, 1 commit per package, no functional spec changes — Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64 for both packages
- [ ] Jenkins/COPR CI green on rhel-10-x86_64 for both packages