### PR TITLE
EL10 rebuild: python-idna, python-sniffio, python-h11, python-httpcore, python-httpx

### DIFF
--- a/packages/python-h11/python-h11.spec
+++ b/packages/python-h11/python-h11.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.16.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A pure-Python, bring-your-own-I/O implementation of HTTP/1
 
 License:        MIT
@@ -50,6 +50,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.16.0-2
+- Bump release for EL10 rebuild
+
 * Fri Apr 25 2025 Foreman Packaging Automation <packaging@theforeman.org> - 0.16.0-1
 - Update to 0.16.0
 

--- a/packages/python-httpcore/python-httpcore.spec
+++ b/packages/python-httpcore/python-httpcore.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.0.9
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A minimal low-level HTTP client
 
 License:        BSD
@@ -55,6 +55,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 1.0.9-2
+- Bump release for EL10 rebuild
+
 * Fri Apr 25 2025 Foreman Packaging Automation <packaging@theforeman.org> - 1.0.9-1
 - Update to 1.0.9
 

--- a/packages/python-httpx/python-httpx.spec
+++ b/packages/python-httpx/python-httpx.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.28.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        The next generation HTTP client.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -54,6 +54,9 @@ set -ex
 %{_bindir}/%{pypi_name}
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.28.1-4
+- Bump release for EL10 rebuild
+
 * Tue Apr 08 2025 Odilon Sousa <osousa@redhat.com> - 0.28.1-3
 - Add obsoletes for python3.11 package
 

--- a/packages/python-idna/python-idna.spec
+++ b/packages/python-idna/python-idna.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.18
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Internationalized Domain Names in Applications (IDNA)
 
 License:        BSD-3-Clause
@@ -47,6 +47,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 3.18-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.18-1
 - Update to 3.18
 - Exclude %{_bindir}/idna (CLI script not shipped in this package)

--- a/packages/python-sniffio/python-sniffio.spec
+++ b/packages/python-sniffio/python-sniffio.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.3.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Sniff out which async library your code is running under
 
 License:        MIT OR Apache-2.0
@@ -53,6 +53,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 1.3.1-2
+- Bump release for EL10 rebuild
+
 * Wed Nov 26 2025 Foreman Packaging Automation <packaging@theforeman.org> - 1.3.1-1
 - Update to 1.3.1
 - Switch to pyproject build (setup.py removed upstream, uses setuptools + setuptools-scm)


### PR DESCRIPTION
## Summary
- EL10 rebuild (theforeman/el10_rebuild#15) — third layer of the poetry tier-gap chain (#2841, #2842). `python3.12-poetry` requires `python3.12dist(pbs-installer[download])`, whose `+download` extra requires `python-httpx >= 0.27`, not built for el10.
- Traced the full chain before opening this PR (to close it in one pass): `httpx -> httpcore -> {anyio (built), certifi (built), h11, sniffio}`, `httpx -> {certifi (built), idna, sniffio}`. `idna`/`sniffio`/`h11` have no further unbuilt Requires. Also confirmed `python-anyio` (already merged tier3) itself needs `idna`+`sniffio` too, so this closes more than one latent gap.
- 5 packages, 1 commit per package, no functional spec changes — Release bump + changelog entry only. No intra-bundle BuildRequires ordering issue (httpx's own BuildRequires are hatch_fancy_pypi_readme/hatchling/tomli, all already merged — httpcore/idna/sniffio/h11 are only needed at httpx's *install* time via Requires, not its build).

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64 for all 5 packages
- [ ] Jenkins/COPR CI green on rhel-10-x86_64 for all 5 packages