### PR TITLE
EL10 rebuild: python-jeepney, python-secretstorage

### DIFF
--- a/packages/python-jeepney/python-jeepney.spec
+++ b/packages/python-jeepney/python-jeepney.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.9.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        This is the extensible, standards compliant build backend used by Hatch.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -44,6 +44,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.9.0-3
+- Bump release for EL10 rebuild
+
 * Tue Mar 25 2025 Odilon Sousa <osousa@redhat.com> - 0.9.0-2
 - Rebuild against python3.12
 

--- a/packages/python-secretstorage/python-secretstorage.spec
+++ b/packages/python-secretstorage/python-secretstorage.spec
@@ -5,7 +5,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.5.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python bindings to FreeDesktop.org Secret Service API
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 3.5.0-2
+- Bump release for EL10 rebuild
+
 * Sun Apr 05 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.5.0-1
 - Update to 3.5.0
 - Fix Source0: tarball filename uses lowercase (secretstorage) since 3.5.0


### PR DESCRIPTION
## Summary
- EL10 rebuild (theforeman/el10_rebuild#15) — fourth layer of the poetry tier-gap chain (#2841, #2842, #2845). `python3.12-poetry` requires `python3.12-keyring` (already merged tier3), which requires `python-SecretStorage` and `python-jeepney`, neither built for el10.
- `python-jeepney` has no further Requires. `python-secretstorage` also requires `python-cryptography`, but that's never appeared in any of the 4 real "nothing provides" errors hit so far in this chain — strong evidence it's already OS-provided on el10 (same pattern as pathspec/pluggy/trove-classifiers earlier), so not pulling it forward.
- 2 packages, 1 commit per package, no functional spec changes — Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64 for both packages
- [ ] Jenkins/COPR CI green on rhel-10-x86_64 for both packages