### PR TITLE
EL10 rebuild: python-urllib3, python-more-itertools

### DIFF
--- a/packages/python-more-itertools/python-more-itertools.spec
+++ b/packages/python-more-itertools/python-more-itertools.spec
@@ -5,7 +5,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        11.1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        This is the extensible, standards compliant build backend used by Hatch.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -45,6 +45,9 @@ set -ex
 %{python3_sitelib}/more_itertools-%{version}.dist-info/
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 11.1.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 11.1.0-1
 - Update to 11.1.0
 

--- a/packages/python-urllib3/python-urllib3.spec
+++ b/packages/python-urllib3/python-urllib3.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.7.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        HTTP library with thread-safe connection pooling, file post, and more
 
 License:        MIT
@@ -46,6 +46,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 2.7.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.7.0-1
 - Update to 2.7.0
 


### PR DESCRIPTION
## Summary
- EL10 rebuild (theforeman/el10_rebuild#15) — fifth layer of the poetry chain, found via a corrected full recursive closure walk of poetry's *entire* Requires tree (this time NOT trusting any already-merged tier3/tier4 package without checking its own Requires — that shortcut is what caused this layer to be missed initially).
- `python3.12-poetry` -> `python3.12-dulwich` (already merged) -> `python-urllib3`, not built for el10. `python-urllib3` is also needed independently by `python-requests` (OS-provided otherwise, but urllib3 itself is a real gap).
- `python3.12-poetry` -> `python3.12-keyring` (already merged) -> `python-jaraco.classes` (already merged) -> `python-more-itertools`, not built for el10.
- Both `urllib3` and `more-itertools` have zero further `Requires` — closes cleanly. Re-ran the full closure walk restricted to true base packages (buildroot/tier1/tier2 only, not tier3) and confirmed every one of poetry's transitive dependencies now resolves once this PR merges, with `python-cryptography` confirmed OS-provided (RHEL10 ships it for python 3.12).
- 2 packages, 1 commit per package, no functional spec changes — Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64 for both packages
- [ ] Jenkins/COPR CI green on rhel-10-x86_64 for both packages