### PR TITLE
Bump python-django-guid release for EL10 rebuild verification

### DIFF
--- a/packages/python-django-guid/python-django-guid.spec
+++ b/packages/python-django-guid/python-django-guid.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.5.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Middleware that enables single request-response cycle tracing by injecting a unique ID into project logs
 
 License:        BSD
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Tue Jul 28 2026 Odilon Sousa <osousa@redhat.com> - 3.5.2-2
+- Bump release for EL10 rebuild
+
 * Sun Nov 30 2025 Foreman Packaging Automation <packaging@theforeman.org> - 3.5.2-1
 - Update to 3.5.2
 


### PR DESCRIPTION
## Summary
- EL10 rebuild (theforeman/el10_rebuild#15) — split out of wave 5 (#2839) since it's the only package in that wave dependent on the ongoing python3.12-poetry tier-gap chain (#2841, #2842, #2845, #2846, #2847, and counting), which shouldn't keep blocking the other 7 clean packages.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64 (blocked until the poetry Requires chain fully resolves)