### PR TITLE
EL10 rebuild: python-distro, python-scikit-build-core

### DIFF
--- a/packages/python-distro/python-distro.spec
+++ b/packages/python-distro/python-distro.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        %{pypi_version}
-Release:        8%{?dist}
+Release:        9%{?dist}
 Summary:        Distro - an OS platform information API
 
 License:        Apache License, Version 2.0
@@ -54,6 +54,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 1.7.0-9
+- Bump release for EL10 rebuild
+
 * Mon Jul 27 2026 Odilon Sousa <osousa@redhat.com> - 1.7.0-8
 - Bump release for EL10 rebuild
 

--- a/packages/python-scikit-build-core/python-scikit-build-core.spec
+++ b/packages/python-scikit-build-core/python-scikit-build-core.spec
@@ -10,7 +10,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.11.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Build backend for CMake based projects
 
 License:        MIT License
@@ -57,5 +57,8 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.11.1-2
+- Bump release for EL10 rebuild
+
 * Tue Jan 16 2024 Odilon Sousa <osousa@redhat.com> -  0.11.1-1
 - Initial package.


### PR DESCRIPTION
## Summary
- EL10 rebuild (theforeman/el10_rebuild#15) — python-scikit-build-core `Requires: python-distro` (plus packaging/pathspec/wheel, already built). python-distro has no further Requires — chain closes cleanly.
- `python-rapidfuzz` split out into its own PR (#2850) — it `BuildRequires: python3.12-scikit-build-core`, and having them bundled unmerged in the same PR meant rapidfuzz's build couldn't see scikit-build-core's commit.
- 2 packages, 1 commit per package, no functional spec changes — Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64 for both packages
- [ ] Jenkins/COPR CI green on rhel-10-x86_64 for both packages