### PR TITLE
Bump python-rapidfuzz release for EL10 rebuild verification

### DIFF
--- a/packages/python-rapidfuzz/python-rapidfuzz.spec
+++ b/packages/python-rapidfuzz/python-rapidfuzz.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.14.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        rapid fuzzy string matching
 
 License:        MIT
@@ -51,6 +51,9 @@ set -ex
 %{python3_sitearch}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 3.14.5-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.14.5-1
 - Update to 3.14.5
 


### PR DESCRIPTION
## Summary
- EL10 rebuild (theforeman/el10_rebuild#15) — split out of #2849 since `python-rapidfuzz` `BuildRequires: python3.12-scikit-build-core`, which needs to be already merged (not just bundled unmerged in the same PR) for rapidfuzz's build to find it.
- No functional spec changes; Release bump + changelog entry only.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64
- [ ] Jenkins/COPR CI green on rhel-10-x86_64 (blocked until #2849 merges)