### PR TITLE
EL10 rebuild: python-importlib-resources, python-inflection, python-isodate, python-jmespath, python-jq, python-json-stream-rs-tokenizer, python-mailbits

### DIFF
--- a/packages/python-importlib-resources/python-importlib-resources.spec
+++ b/packages/python-importlib-resources/python-importlib-resources.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        6.4.5
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Read resources from Python packages
 
 License:        Apache2
@@ -48,6 +48,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 6.4.5-4
+- Bump release for EL10 rebuild
+
 * Wed Jul 22 2026 Odilon Sousa <osousa@redhat.com> - 6.4.5-3
 - Restore package: python3.12-pulp-rpm declares importlib-resources as an
   unconditional (non-marker-gated) upstream dependency, so it was

--- a/packages/python-inflection/python-inflection.spec
+++ b/packages/python-inflection/python-inflection.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.5.1
-Release:        8%{?dist}
+Release:        9%{?dist}
 Summary:        A port of Ruby on Rails inflector to Python
 
 License:        MIT
@@ -48,6 +48,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.5.1-9
+- Bump release for EL10 rebuild
+
 * Wed Apr 02 2025 Odilon Sousa <osousa@redhat.com> - 0.5.1-8
 - Rebuild against python3.12
 

--- a/packages/python-isodate/python-isodate.spec
+++ b/packages/python-isodate/python-isodate.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.7.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        An ISO 8601 date/time/duration parser and formatter
 
 License:        BSD
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.7.2-3
+- Bump release for EL10 rebuild
+
 * Tue Apr 01 2025 Odilon Sousa <osousa@redhat.com> - 0.7.2-2
 - Rebuild against python3.12
 

--- a/packages/python-jmespath/python-jmespath.spec
+++ b/packages/python-jmespath/python-jmespath.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        JSON Matching Expressions
 
 License:        MIT
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 1.1.0-2
+- Bump release for EL10 rebuild
+
 * Sun Mar 22 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.1.0-1
 - Update to 1.1.0
 - Fix license filename (LICENSE.txt -> LICENSE)

--- a/packages/python-jq/python-jq.spec
+++ b/packages/python-jq/python-jq.spec
@@ -9,7 +9,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.11.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        jq is a lightweight and flexible JSON processor
 
 License:        BSD 2-Clause
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 1.11.0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.11.0-1
 - Update to 1.11.0
 

--- a/packages/python-json-stream-rs-tokenizer/python-json-stream-rs-tokenizer.spec
+++ b/packages/python-json-stream-rs-tokenizer/python-json-stream-rs-tokenizer.spec
@@ -10,7 +10,7 @@
 
 Name:           python%{python3_pkgversion}-%{pkg_name}
 Version:        0.5.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Faster tokenizer for the json-stream Python library
 
 License:        MIT
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.5.1-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.5.1-1
 - Update to 0.5.1
 

--- a/packages/python-mailbits/python-mailbits.spec
+++ b/packages/python-mailbits/python-mailbits.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.2.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Assorted e-mail utility functions
 
 License:        MIT
@@ -49,6 +49,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.2.1-3
+- Bump release for EL10 rebuild
+
 * Mon Mar 31 2025 Odilon Sousa <osousa@redhat.com> - 0.2.1-2
 - Rebuild against python3.12
 


### PR DESCRIPTION
## Summary
- EL10 rebuild tier4 wave 8 (theforeman/el10_rebuild#15) — bump Release for 7 independent tier4 packages to produce real, verifiable builds for both EL9 and EL10.
- 7 packages, 1 commit per package, no functional spec changes — Release bump + changelog entry only.
- Originally 8 packages; dropped `python-json-stream` — it `Requires: python-json_stream_rs_tokenizer`, which is also in this wave, so bundling them together would have broken the build once json-stream tried to install its own dependency mid-PR. `python-json-stream-rs-tokenizer` stays in this wave; `python-json-stream` will follow once this merges.
- No other intra-wave dependencies (checked via automated audit); also cross-checked against wave 7 (#2851, open simultaneously) — no dependencies in either direction.

## Test plan
- [ ] Jenkins/COPR CI green on rhel-9-x86_64 for all 7 packages
- [ ] Jenkins/COPR CI green on rhel-10-x86_64 for all 7 packages