### PR TITLE
EL10 rebuild: python-json-stream, python-markdown, python-markuppy, python-markupsafe, python-mccabe, python-mdurl, python-multidict, python-mypy-extensions, python-nh3, python-odfpy

### DIFF
--- a/packages/python-json-stream/python-json-stream.spec
+++ b/packages/python-json-stream/python-json-stream.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pkg_name}
 Version:        2.4.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Streaming JSON encoder and decoder
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -50,6 +50,9 @@ set -ex
 %{python3_sitelib}/%{pkg_name}/
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 2.4.1-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.4.1-1
 - Update to 2.4.1
 

--- a/packages/python-markdown/python-markdown.spec
+++ b/packages/python-markdown/python-markdown.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        3.8.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python implementation of Markdown
 
 License:        BSD License
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 3.8.2-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 09 2025 Foreman Packaging Automation <packaging@theforeman.org> - 3.8.2-1
 - Update to 3.8.2
 - Fix PEP 639 license format in pyproject.toml

--- a/packages/python-markuppy/python-markuppy.spec
+++ b/packages/python-markuppy/python-markuppy.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        1.18
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        An HTML/XML generator
 
 License:        MIT
@@ -48,6 +48,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 1.18-2
+- Bump release for EL10 rebuild
+
 * Sun Mar 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.18-1
 - Update to 1.18
 - Fix Source0: tarball filename uses lowercase (markuppy) since 1.18

--- a/packages/python-markupsafe/python-markupsafe.spec
+++ b/packages/python-markupsafe/python-markupsafe.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        3.0.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Safely add untrusted strings to HTML/XML markup
 
 License:        BSD-3-Clause
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 3.0.3-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 01 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.0.3-1
 - Update to 3.0.3
 - Fix PEP 639 license field incompatibility with RHEL 9 setuptools

--- a/packages/python-mccabe/python-mccabe.spec
+++ b/packages/python-mccabe/python-mccabe.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.7.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        McCabe checker, plugin for flake8
 
 License:        Expat license
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.7.0-6
+- Bump release for EL10 rebuild
+
 * Tue Apr 01 2025 Odilon Sousa <osousa@redhat.com> - 0.7.0-5
 - Rebuild against python3.12
 

--- a/packages/python-mdurl/python-mdurl.spec
+++ b/packages/python-mdurl/python-mdurl.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.1.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Markdown URL utilities
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -43,6 +43,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.1.2-3
+- Bump release for EL10 rebuild
+
 * Thu Apr 03 2025 Odilon Sousa <osousa@redhat.com> - 0.1.2-2
 - Drop flit_core as requirement
 

--- a/packages/python-multidict/python-multidict.spec
+++ b/packages/python-multidict/python-multidict.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        6.7.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        multidict implementation
 
 License:        Apache 2
@@ -47,6 +47,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 6.7.1-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 6.7.1-1
 - Update to 6.7.1
 

--- a/packages/python-mypy-extensions/python-mypy-extensions.spec
+++ b/packages/python-mypy-extensions/python-mypy-extensions.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Type system extensions for mypy
 
 License:        MIT
@@ -50,5 +50,8 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 1.1.0-2
+- Bump release for EL10 rebuild
+
 * Fri Jun 12 2026 Odilon Sousa <osousa@redhat.com> - 1.1.0-1
 - Initial package

--- a/packages/python-nh3/python-nh3.spec
+++ b/packages/python-nh3/python-nh3.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.3.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python binding to Ammonia HTML sanitizer Rust crate
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -62,6 +62,9 @@ set -ex
 %{python3_sitearch}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.3.6-2
+- Bump release for EL10 rebuild
+
 * Sun Jun 28 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.3.6-1
 - Update to 0.3.6
 

--- a/packages/python-odfpy/python-odfpy.spec
+++ b/packages/python-odfpy/python-odfpy.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.4.1
-Release:        11%{?dist}
+Release:        12%{?dist}
 Summary:        Python API and tools to manipulate OpenDocument files
 
 License:        GPLv2+ or Apache-2.0
@@ -71,6 +71,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 1.4.1-12
+- Bump release for EL10 rebuild
+
 * Mon Mar 31 2025 Odilon Sousa <osousa@redhat.com> - 1.4.1-11
 - Rebuild against python3.12
 


### PR DESCRIPTION
Wave 9 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). One commit per package, release bump only, no functional changes.

python-json-stream's runtime `Requires: python3.12-json_stream_rs_tokenizer` is satisfied by #2852 (merged), so it's included here rather than waiting for a separate wave.

Checked for same-wave BuildRequires/Requires overlaps and did a full transitive closure walk against everything already built for el10 this campaign — no gaps found.