### PR TITLE
EL10 rebuild: python-wrapt, python-opentelemetry_api, python-opentelemetry_proto, python-opentelemetry_semantic_conventions, python-parsley, python-pillow, python-prometheus-client, python-propcache, python-psycopg, python-psycopg_c, python-ptyprocess

### DIFF
--- a/packages/python-opentelemetry_api/python-opentelemetry_api.spec
+++ b/packages/python-opentelemetry_api/python-opentelemetry_api.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.40.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        OpenTelemetry Python API.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -48,6 +48,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 1.40.0-3
+- Bump release for EL10 rebuild
+
 * Mon Jul 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.40.0-2
 - Drop importlib-metadata requirement
 

--- a/packages/python-opentelemetry_proto/python-opentelemetry_proto.spec
+++ b/packages/python-opentelemetry_proto/python-opentelemetry_proto.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.40.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OpenTelemetry Python Proto.
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -49,6 +49,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 1.40.0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.40.0-1
 - Update to 1.40.0
 - Fix protobuf upper bound: < 6 -> < 7 (upstream requires protobuf<7,>=5)

--- a/packages/python-opentelemetry_semantic_conventions/python-opentelemetry_semantic_conventions.spec
+++ b/packages/python-opentelemetry_semantic_conventions/python-opentelemetry_semantic_conventions.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.61b0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OpenTelemetry Semantic Conventions
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -48,6 +48,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.61b0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.61b0-1
 - Update to 0.61b0
 

--- a/packages/python-parsley/python-parsley.spec
+++ b/packages/python-parsley/python-parsley.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        1.3
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        Parsing and pattern matching made easy
 
 License:        MIT License
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 1.3-8
+- Bump release for EL10 rebuild
+
 * Tue Apr 01 2025 Odilon Sousa <osousa@redhat.com> - 1.3-7
 - Rebuild against python3.12
 

--- a/packages/python-pillow/python-pillow.spec
+++ b/packages/python-pillow/python-pillow.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        12.3.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python Imaging Library (Fork)
 
 License:        HPND
@@ -54,6 +54,9 @@ set -ex
 %{python3_sitearch}/%{srcname}-%{version}.dist-info/
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 12.3.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 12.3.0-1
 - Update to 12.3.0
 

--- a/packages/python-prometheus-client/python-prometheus-client.spec
+++ b/packages/python-prometheus-client/python-prometheus-client.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.8.0
-Release:        8%{?dist}
+Release:        9%{?dist}
 Summary:        Python client for the Prometheus monitoring system
 
 License:        Apache Software License 2.0
@@ -47,6 +47,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.8.0-9
+- Bump release for EL10 rebuild
+
 * Mon Mar 31 2025 Odilon Sousa <osousa@redhat.com> - 0.8.0-8
 - Rebuild against python 3.12
 

--- a/packages/python-propcache/python-propcache.spec
+++ b/packages/python-propcache/python-propcache.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.5.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Fast property caching.
 
 License:        Apache-2.0
@@ -47,6 +47,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.5.2-2
+- Bump release for EL10 rebuild
+
 * Sun May 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.5.2-1
 - Update to 0.5.2
 

--- a/packages/python-psycopg/python-psycopg.spec
+++ b/packages/python-psycopg/python-psycopg.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.2.13
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        PostgreSQL database adapter for Python
 
 License:        GNU Lesser General Public License v3 (LGPLv3)
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 3.2.13-2
+- Bump release for EL10 rebuild
+
 * Mon Mar 30 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.2.13-1
 - Update to 3.2.13
 

--- a/packages/python-psycopg_c/python-psycopg_c.spec
+++ b/packages/python-psycopg_c/python-psycopg_c.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.2.13
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        PostgreSQL database adapter for Python - C extension
 
 License:        LGPL-3.0-only
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 3.2.13-2
+- Bump release for EL10 rebuild
+
 * Mon Mar 30 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.2.13-1
 - Update to 3.2.13
 

--- a/packages/python-ptyprocess/python-ptyprocess.spec
+++ b/packages/python-ptyprocess/python-ptyprocess.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.7.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Run a subprocess in a pseudo terminal
 
 License:        None
@@ -46,6 +46,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.7.0-7
+- Bump release for EL10 rebuild
+
 * Tue Mar 25 2025 Odilon Sousa <osousa@redhat.com> - 0.7.0-6
 - Rebuild against python3.12
 

--- a/packages/python-wrapt/python-wrapt.spec
+++ b/packages/python-wrapt/python-wrapt.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.17.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Module for decorators, wrappers and monkey patching
 
 License:        BSD
@@ -47,6 +47,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 1.17.3-2
+- Bump release for EL10 rebuild
+
 * Sun Sep 21 2025 Foreman Packaging Automation <packaging@theforeman.org> - 1.17.3-1
 - Update to 1.17.3
 


### PR DESCRIPTION
Wave 10 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). One commit per package, release bump only, no functional changes.

python-wrapt is pulled in ahead of its originally-planned wave — it's a runtime `Requires` of python-deprecated (already built for el10), and python-opentelemetry_api itself `Requires: python-deprecated`, so wrapt needed to land before this wave could complete a full install chain.

Checked for same-wave BuildRequires/Requires overlaps and did a full transitive closure walk against everything already built for el10 this campaign — no other gaps found.