### PR TITLE
EL10 rebuild: python-pyasn1, python-pycodestyle, python-pycparser, python-pydantic-core, python-pyflakes, python-pygments, python-pygobject, python-pygtrie, python-pyrsistent, python-pysequoia

### DIFF
--- a/packages/python-pyasn1/python-pyasn1.spec
+++ b/packages/python-pyasn1/python-pyasn1.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.6.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        ASN.1 types and codecs
 
 License:        BSD
@@ -53,6 +53,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.6.3-2
+- Bump release for EL10 rebuild
+
 * Sun Mar 22 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.6.3-1
 - Update to 0.6.3
 - Switch to pyproject build (setup.py removed upstream)

--- a/packages/python-pycodestyle/python-pycodestyle.spec
+++ b/packages/python-pycodestyle/python-pycodestyle.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.11.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Python style guide checker
 
 License:        Expat license
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 2.11.1-4
+- Bump release for EL10 rebuild
+
 * Wed Apr 09 2025 Odilon Sousa <osousa@redhat.com> - 2.11.1-3
 - Add obsoletes for python3.11 package
 

--- a/packages/python-pycparser/python-pycparser.spec
+++ b/packages/python-pycparser/python-pycparser.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        C parser in Python
 
 License:        BSD
@@ -56,6 +56,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 3.0-2
+- Bump release for EL10 rebuild
+
 * Sun Mar 22 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.0-1
 - Update to 3.0
 - Switch to pyproject build; patch pyproject.toml for RHEL9 pip compatibility

--- a/packages/python-pydantic-core/python-pydantic-core.spec
+++ b/packages/python-pydantic-core/python-pydantic-core.spec
@@ -10,7 +10,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.46.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Data validation using Python type hints
 
 License:        MIT
@@ -68,6 +68,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 2.46.4-3
+- Bump release for EL10 rebuild
+
 * Wed May 27 2026 Odilon Sousa <osousa@redhat.com> - 2.46.4-2
 - Update typing-extensions lower bound to >= 4.14.1 to match upstream 2.46.4
 

--- a/packages/python-pyflakes/python-pyflakes.spec
+++ b/packages/python-pyflakes/python-pyflakes.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.1.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        passive checker of Python programs
 
 License:        MIT
@@ -50,6 +50,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 3.1.0-3
+- Bump release for EL10 rebuild
+
 * Wed Apr 02 2025 Odilon Sousa <osousa@redhat.com> - 3.1.0-2
 - Rebuild against python3.12
 

--- a/packages/python-pygments/python-pygments.spec
+++ b/packages/python-pygments/python-pygments.spec
@@ -8,7 +8,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        2.20.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Pygments is a syntax highlighting package written in Python
 
 License:        BSD
@@ -50,6 +50,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 2.20.0-2
+- Bump release for EL10 rebuild
+
 * Mon Mar 30 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.20.0-1
 - Update to 2.20.0
 

--- a/packages/python-pygobject/python-pygobject.spec
+++ b/packages/python-pygobject/python-pygobject.spec
@@ -9,7 +9,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        3.50.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Epoch:          1
 Summary:        Python bindings for GObject Introspection
 
@@ -64,6 +64,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 1:3.50.2-2
+- Bump release for EL10 rebuild
+
 * Wed Oct 22 2025 Foreman Packaging Automation <packaging@theforeman.org> - 1:3.50.2-1
 - Update to 3.50.2
 

--- a/packages/python-pygtrie/python-pygtrie.spec
+++ b/packages/python-pygtrie/python-pygtrie.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.5.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        A pure Python trie data structure implementation
 
 License:        Apache-2.0
@@ -46,6 +46,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 2.5.0-7
+- Bump release for EL10 rebuild
+
 * Wed Apr 02 2025 Odilon Sousa <osousa@redhat.com> - 2.5.0-6
 - Rebuild against python3.12
 

--- a/packages/python-pyrsistent/python-pyrsistent.spec
+++ b/packages/python-pyrsistent/python-pyrsistent.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.18.1
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        Persistent/Functional/Immutable data structures
 
 License:        MIT
@@ -48,6 +48,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.18.1-8
+- Bump release for EL10 rebuild
+
 * Tue Apr 01 2025 Odilon Sousa <osousa@redhat.com> - 0.18.1-7
 - Rebuild against python3.12
 

--- a/packages/python-pysequoia/python-pysequoia.spec
+++ b/packages/python-pysequoia/python-pysequoia.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.1.34
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Provides OpenPGP facilities using Sequoia-PGP library
 
 License:        Apache-2.0
@@ -64,6 +64,9 @@ set -ex
 
 
 %changelog
+* Wed Jul 29 2026 Odilon Sousa <osousa@redhat.com> - 0.1.34-2
+- Bump release for EL10 rebuild
+
 * Wed May 27 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.1.34-1
 - Update to 0.1.34
 - Regenerate vendor tarball for 0.1.34


### PR DESCRIPTION
Wave 11 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). One commit per package, release bump only, no functional changes.

Checked for same-wave BuildRequires/Requires overlaps, cross-checked against wave 10 (#2854, still open at the time this was opened), and did a full transitive closure walk against everything already built for el10 this campaign — no gaps found.