### PR TITLE
EL10 rebuild: python-redis, python-requirements-parser, python-rfc3986, python-rfc8785, python-ruamel-yaml-clib, python-s3transfer, python-schema, python-securesystemslib, python-six

### DIFF
--- a/packages/python-redis/python-redis.spec
+++ b/packages/python-redis/python-redis.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        7.1.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python client for Redis database and key-value store
 
 License:        MIT
@@ -55,6 +55,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 7.1.1-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 7.1.1-1
 - Update to 7.1.1
 

--- a/packages/python-requirements-parser/python-requirements-parser.spec
+++ b/packages/python-requirements-parser/python-requirements-parser.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.2.0
-Release:        8%{?dist}
+Release:        9%{?dist}
 Summary:        Parses Pip requirement files
 
 License:        BSD
@@ -48,6 +48,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.2.0-9
+- Bump release for EL10 rebuild
+
 * Tue Apr 01 2025 Odilon Sousa <osousa@redhat.com> - 0.2.0-8
 - Rebuild against python3.12
 

--- a/packages/python-rfc3986/python-rfc3986.spec
+++ b/packages/python-rfc3986/python-rfc3986.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Validating URI References per the RFC
 
 License:        Apache-2.0
@@ -49,5 +49,8 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.0.0-2
+- Bump release for EL10 rebuild
+
 * Tue Apr 14 2026 Odilon Sousa <osousa@redhat.com> - 2.0.0-1
 - Initial package.

--- a/packages/python-rfc8785/python-rfc8785.spec
+++ b/packages/python-rfc8785/python-rfc8785.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.1.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        JSON Canonicalization Scheme (JCS) implementation per RFC 8785
 
 License:        Apache-2.0
@@ -47,5 +47,8 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.1.4-2
+- Bump release for EL10 rebuild
+
 * Tue Apr 14 2026 Odilon Sousa <osousa@redhat.com> - 0.1.4-1
 - Initial package.

--- a/packages/python-ruamel-yaml-clib/python-ruamel-yaml-clib.spec
+++ b/packages/python-ruamel-yaml-clib/python-ruamel-yaml-clib.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        0.2.14
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        C version of reader, parser and emitter for ruamel
 
 License:        MIT
@@ -53,6 +53,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.2.14-2
+- Bump release for EL10 rebuild
+
 * Thu Oct 02 2025 Foreman Packaging Automation <packaging@theforeman.org> - 0.2.14-1
 - Update to 0.2.14
 - Migrate to pyproject_wheel build macros

--- a/packages/python-s3transfer/python-s3transfer.spec
+++ b/packages/python-s3transfer/python-s3transfer.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.19.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        An Amazon S3 Transfer Manager
 
 License:        Apache License 2.0
@@ -50,6 +50,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.19.0-2
+- Bump release for EL10 rebuild
+
 * Sun Jun 28 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.19.0-1
 - Update to 0.19.0
 

--- a/packages/python-schema/python-schema.spec
+++ b/packages/python-schema/python-schema.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.7.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Simple data validation library
 
 License:        MIT
@@ -49,6 +49,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.7.8-2
+- Bump release for EL10 rebuild
+
 * Sun Apr 05 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.7.8-1
 - Update to 0.7.8
 - Update %%files for schema 0.7.8 package restructure (schema.py → schema/)

--- a/packages/python-securesystemslib/python-securesystemslib.spec
+++ b/packages/python-securesystemslib/python-securesystemslib.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.4.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A library that provides cryptographic and general-purpose routines
 
 License:        MIT
@@ -49,6 +49,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.4.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.4.0-1
 - Update to 1.4.0
 

--- a/packages/python-six/python-six.spec
+++ b/packages/python-six/python-six.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.17.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Python 2 and 3 compatibility utilities
 
 License:        MIT
@@ -50,6 +50,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.17.0-3
+- Bump release for EL10 rebuild
+
 * Mon Mar 24 2025 Odilon Sousa <osousa@redhat.com> - 1.17.0-2
 - Rebuild against python3.12
 


### PR DESCRIPTION
Wave 12 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). 9 packages, one commit per package (`obal bump-release --changelog`).

No same-wave BuildRequires/Requires ordering issues — verified by pre-flight audit: none of these packages depend on each other, and the only manifest dependency (`python-s3transfer` -> `python-botocore`) is already built (tier4 wave 3).

Ref: theforeman/el10_rebuild#15