### PR TITLE
EL10 rebuild: python-smmap, python-socks, python-solv, python-soupsieve, python-subprocess-tee, python-typing-inspection, python-uritemplate

### DIFF
--- a/packages/python-smmap/python-smmap.spec
+++ b/packages/python-smmap/python-smmap.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        5.0.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A pure Python implementation of a sliding window memory map manager
 
 License:        BSD-3-Clause
@@ -49,6 +49,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 5.0.3-2
+- Bump release for EL10 rebuild
+
 * Sun Mar 22 2026 Foreman Packaging Automation <packaging@theforeman.org> - 5.0.3-1
 - Update to 5.0.3
 

--- a/packages/python-socks/python-socks.spec
+++ b/packages/python-socks/python-socks.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        2.8.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Core proxy (SOCKS4, SOCKS5, HTTP tunneling) functionality for Python
 
 License:        Apache 2
@@ -64,6 +64,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.8.2-3
+- Bump release for EL10 rebuild
+
 * Mon Jul 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 2.8.2-2
 - Drop async-timeout requirement from +asyncio subpackage
 

--- a/packages/python-solv/python-solv.spec
+++ b/packages/python-solv/python-solv.spec
@@ -30,7 +30,7 @@
 
 Name:           python%{python3_pkgversion}-%{libname}
 Version:        0.7.28
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Python bindings for the lib%{libname} library
 
 License:        BSD
@@ -150,6 +150,9 @@ export LD_LIBRARY_PATH=%{buildroot}%{_libdir}
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.7.28-3
+- Bump release for EL10 rebuild
+
 * Wed Apr 02 2025 Odilon Sousa <osousa@redhat.com> - 0.7.28-2
 - Rebuild against python3.12
 

--- a/packages/python-soupsieve/python-soupsieve.spec
+++ b/packages/python-soupsieve/python-soupsieve.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.8.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A modern CSS selector implementation for Beautiful Soup
 
 License:        MIT License
@@ -44,6 +44,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.8.4-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.8.4-1
 - Update to 2.8.4
 

--- a/packages/python-subprocess-tee/python-subprocess-tee.spec
+++ b/packages/python-subprocess-tee/python-subprocess-tee.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.4.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A subprocess.run alternative that also allows capturing combined stdout/stderr
 
 License:        MIT
@@ -50,5 +50,8 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.4.2-2
+- Bump release for EL10 rebuild
+
 * Fri Jun 12 2026 Odilon Sousa <osousa@redhat.com> - 0.4.2-1
 - Initial package

--- a/packages/python-typing-inspection/python-typing-inspection.spec
+++ b/packages/python-typing-inspection/python-typing-inspection.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.4.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Data validation using Python type hints
 
 License:        MIT
@@ -46,6 +46,9 @@ set -ex
 %{python3_sitelib}/%{srcname}-%{version}.dist-info/
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.4.2-2
+- Bump release for EL10 rebuild
+
 * Wed Oct 22 2025 Foreman Packaging Automation <packaging@theforeman.org> - 0.4.2-1
 - Update to 0.4.2
 

--- a/packages/python-uritemplate/python-uritemplate.spec
+++ b/packages/python-uritemplate/python-uritemplate.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        4.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Implementation of RFC 6570 URI Templates
 
 License:        BSD 3-Clause License or Apache License, Version 2.0
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 4.2.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 04 2025 Foreman Packaging Automation <packaging@theforeman.org> - 4.2.0-1
 - Update to 4.2.0
 


### PR DESCRIPTION
Wave 13 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). 7 packages, one commit per package (`obal bump-release --changelog`).

Dropped from this wave: `python-toml` hardcodes `%global python3_pkgversion 3.11` (no python3.11-devel on el10) — tracked in theforeman/el10_rebuild#22, not fixed inline.

No same-wave BuildRequires/Requires ordering issues — pre-flight audit confirmed none of these packages depend on each other. External Requires (`python-typing-inspection` -> `python-typing-extensions`, tier2, already built) are already satisfied.

Ref: theforeman/el10_rebuild#15