### PR TITLE
EL10 rebuild: python-urlman, python-userpath, python-uuid6, python-wcmatch, python-whitenoise, python-yamllint, python-zipp

### DIFF
--- a/packages/python-urlman/python-urlman.spec
+++ b/packages/python-urlman/python-urlman.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.0.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Django URL pattern helpers
 
 License:        Apache-2.0
@@ -48,6 +48,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.0.1-7
+- Bump release for EL10 rebuild
+
 * Mon Mar 31 2025 Odilon Sousa <osousa@redhat.com> - 2.0.1-6
 - Rebuild against python3.12
 

--- a/packages/python-userpath/python-userpath.spec
+++ b/packages/python-userpath/python-userpath.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.9.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Cross-platform tool for adding locations to the user PATH, no elevated privileges required!
 
 License:        MIT OR Apache-2.0
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.9.2-4
+- Bump release for EL10 rebuild
+
 * Wed Apr 09 2025 Odilon Sousa <osousa@redhat.com> - 1.9.2-3
 - Add obsoletes for python3.11 package
 

--- a/packages/python-uuid6/python-uuid6.spec
+++ b/packages/python-uuid6/python-uuid6.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2025.0.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        New time-based UUID formats which are suited for use as a database key
 
 License:        MIT
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2025.0.1-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 01 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2025.0.1-1
 - Update to 2025.0.1
 - Switch to pyproject build (setup.py removed upstream); add setuptools-scm

--- a/packages/python-wcmatch/python-wcmatch.spec
+++ b/packages/python-wcmatch/python-wcmatch.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        10.2.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Wildcard/glob file name matcher
 
 License:        MIT License
@@ -47,6 +47,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 10.2.1-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 10.2.1-1
 - Update to 10.2.1
 

--- a/packages/python-whitenoise/python-whitenoise.spec
+++ b/packages/python-whitenoise/python-whitenoise.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        6.12.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Radically simplified static file serving for WSGI applications
 
 License:        MIT
@@ -50,6 +50,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 6.12.0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 6.12.0-1
 - Update to 6.12.0
 

--- a/packages/python-yamllint/python-yamllint.spec
+++ b/packages/python-yamllint/python-yamllint.spec
@@ -5,7 +5,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.38.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A linter for YAML files
 
 License:        GPLv3+
@@ -54,5 +54,8 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.38.0-2
+- Bump release for EL10 rebuild
+
 * Fri Jun 12 2026 Odilon Sousa <osousa@redhat.com> - 1.38.0-1
 - Initial package

--- a/packages/python-zipp/python-zipp.spec
+++ b/packages/python-zipp/python-zipp.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        4.1.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Backport of pathlib-compatible object wrapper for zip files
 
 License:        MIT
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 4.1.0-3
+- Bump release for EL10 rebuild
+
 * Wed Jul 22 2026 Odilon Sousa <osousa@redhat.com> - 4.1.0-2
 - Restore package: python3.12-importlib-metadata (restored in this same PR)
   declares zipp>=0.5 as an unconditional upstream dependency, so it was


### PR DESCRIPTION
Wave 14 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). 7 packages, one commit per package (`obal bump-release --changelog`).

No same-wave BuildRequires/Requires ordering issues — pre-flight audit confirmed none of these packages depend on each other. External Requires (`python-userpath` -> `python-click` wave4, `python-wcmatch` -> `python-bracex` wave3, `python-yamllint` -> `python-pathspec`/`python-pyyaml` OS-provided/buildroot) are all already satisfied.

Ref: theforeman/el10_rebuild#15