### PR TITLE
EL10 rebuild: python-cffi, python-email-validator, python-flake8, python-gitdb, python-google-resumable-media, python-googleapis-common-protos, python-hyperlink, python-id, python-importlib-metadata

### DIFF
--- a/packages/python-cffi/python-cffi.spec
+++ b/packages/python-cffi/python-cffi.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Foreign Function Interface for Python calling C code
 
 License:        MIT
@@ -57,6 +57,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.1.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.1.0-1
 - Update to 2.1.0
 - Remove PEP 639 license-files field incompatible with RHEL 9 setuptools

--- a/packages/python-email-validator/python-email-validator.spec
+++ b/packages/python-email-validator/python-email-validator.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.3.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A robust email address syntax and deliverability validation library
 
 License:        Unlicense
@@ -54,5 +54,8 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.3.0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Odilon Sousa <osousa@redhat.com> - 2.3.0-1
 - Initial package.

--- a/packages/python-flake8/python-flake8.spec
+++ b/packages/python-flake8/python-flake8.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        6.1.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        the modular source code checker: pep8 pyflakes and co
 
 License:        MIT
@@ -60,6 +60,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 6.1.0-5
+- Bump release for EL10 rebuild
+
 * Mon Jul 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 6.1.0-4
 - Drop importlib-metadata requirement
 

--- a/packages/python-gitdb/python-gitdb.spec
+++ b/packages/python-gitdb/python-gitdb.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        4.0.12
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Git Object Database
 
 License:        BSD License
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 4.0.12-3
+- Bump release for EL10 rebuild
+
 * Tue Apr 01 2025 Odilon Sousa <osousa@redhat.com> - 4.0.12-2
 - Rebuild against python3.12
 

--- a/packages/python-google-resumable-media/python-google-resumable-media.spec
+++ b/packages/python-google-resumable-media/python-google-resumable-media.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.10.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Utilities for Google Media Downloads and Resumable Uploads
 
 License:        Apache 2.0
@@ -55,6 +55,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.10.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.10.0-1
 - Update to 2.10.0
 

--- a/packages/python-googleapis-common-protos/python-googleapis-common-protos.spec
+++ b/packages/python-googleapis-common-protos/python-googleapis-common-protos.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.75.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Common protobufs used in Google APIs
 
 License:        Apache-2.0
@@ -64,6 +64,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.75.0-2
+- Bump release for EL10 rebuild
+
 * Sun May 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.75.0-1
 - Update to 1.75.0
 

--- a/packages/python-hyperlink/python-hyperlink.spec
+++ b/packages/python-hyperlink/python-hyperlink.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        21.0.0
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        A featureful, immutable, and correct URL for Python
 
 License:        MIT
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 21.0.0-7
+- Bump release for EL10 rebuild
+
 * Wed Mar 26 2025 Odilon Sousa <osousa@redhat.com> - 21.0.0-6
 - Rebuild against python3.12
 

--- a/packages/python-id/python-id.spec
+++ b/packages/python-id/python-id.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.6.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A library for generating OIDC identities
 
 License:        Apache-2.0
@@ -50,5 +50,8 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.6.1-2
+- Bump release for EL10 rebuild
+
 * Tue Apr 14 2026 Odilon Sousa <osousa@redhat.com> - 1.6.1-1
 - Initial package.

--- a/packages/python-importlib-metadata/python-importlib-metadata.spec
+++ b/packages/python-importlib-metadata/python-importlib-metadata.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        6.0.1
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        Read metadata from Python packages
 
 License:        Apache Software License
@@ -53,6 +53,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 6.0.1-8
+- Bump release for EL10 rebuild
+
 * Wed Jul 22 2026 Odilon Sousa <osousa@redhat.com> - 6.0.1-7
 - Restore package: python3.12-opentelemetry_api and python3.12-bandersnatch
   declare importlib-metadata as an unconditional (non-marker-gated) upstream


### PR DESCRIPTION
Wave 15 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). 9 packages, one commit per package (`obal bump-release --changelog`).

No same-wave BuildRequires/Requires ordering issues — pre-flight audit confirmed none of these packages depend on each other. External Requires (dnspython, idna, mccabe, pycodestyle, pyflakes, smmap, google-crc32c, grpcio, protobuf, urllib3, zipp) are all already built in earlier merged waves/tiers.

Ref: theforeman/el10_rebuild#15