### PR TITLE
EL10 rebuild: python-iniparse, python-jinja2, python-jsonschema, python-markdown-it-py, python-openpyxl, python-opentelemetry_exporter_otlp_proto_common, python-opentelemetry_sdk, python-pexpect, python-productmd, python-pyasn1-modules

### DIFF
--- a/packages/python-iniparse/python-iniparse.spec
+++ b/packages/python-iniparse/python-iniparse.spec
@@ -8,7 +8,7 @@
 
 Name:           python%{python3_pkgversion}-%{modname}
 Version:        0.5
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Python Module for Accessing and Modifying Configuration Data in INI files
 License:        MIT and Python
 URL:            https://pypi.org/project/iniparse/
@@ -68,6 +68,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.5-3
+- Bump release for EL10 rebuild
+
 * Wed Apr 02 2025 Odilon Sousa <osousa@redhat.com> - 0.5-2
 - Rebuild against python3.12
 

--- a/packages/python-jinja2/python-jinja2.spec
+++ b/packages/python-jinja2/python-jinja2.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        3.1.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A very fast and expressive template engine
 
 License:        BSD-3-Clause
@@ -49,6 +49,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 3.1.6-2
+- Bump release for EL10 rebuild
+
 * Fri Apr 04 2025 Foreman Packaging Automation <packaging@theforeman.org> - 3.1.6-1
 - Update to 3.1.6
 

--- a/packages/python-jsonschema/python-jsonschema.spec
+++ b/packages/python-jsonschema/python-jsonschema.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        4.10.3
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        An implementation of JSON Schema validation for Python
 
 License:        MIT
@@ -53,6 +53,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 4.10.3-7
+- Bump release for EL10 rebuild
+
 * Tue Apr 08 2025 Odilon Sousa <osousa@redhat.com> - 4.10.3-6
 - Add obsoletes for python3.11 package
 

--- a/packages/python-markdown-it-py/python-markdown-it-py.spec
+++ b/packages/python-markdown-it-py/python-markdown-it-py.spec
@@ -5,7 +5,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python port of markdown-it. Markdown parsing, done right!
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -47,5 +47,8 @@ set -ex
 %{python3_sitelib}/%{src_name}-%{version}.dist-info/
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.2.0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 02 2025 Odilon Sousa <osousa@redhat.com> - 2.2.0-1
 - Initial package.

--- a/packages/python-openpyxl/python-openpyxl.spec
+++ b/packages/python-openpyxl/python-openpyxl.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.1.5
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A Python library to read/write Excel 2010 xlsx/xlsm files
 
 License:        MIT
@@ -49,6 +49,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 3.1.5-3
+- Bump release for EL10 rebuild
+
 * Mon Mar 31 2025 Odilon Sousa <osousa@redhat.com> - 3.1.5-2
 - Rebuild against python3.12
 

--- a/packages/python-opentelemetry_exporter_otlp_proto_common/python-opentelemetry_exporter_otlp_proto_common.spec
+++ b/packages/python-opentelemetry_exporter_otlp_proto_common/python-opentelemetry_exporter_otlp_proto_common.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.40.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OpenTelemetry Protobuf encoding
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -49,6 +49,9 @@ set -ex
 %{python3_sitelib}/opentelemetry/exporter/otlp
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.40.0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.40.0-1
 - Update to 1.40.0
 

--- a/packages/python-opentelemetry_sdk/python-opentelemetry_sdk.spec
+++ b/packages/python-opentelemetry_sdk/python-opentelemetry_sdk.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.40.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OpenTelemetry Python SDK
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -50,6 +50,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.40.0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.40.0-1
 - Update to 1.40.0
 

--- a/packages/python-pexpect/python-pexpect.spec
+++ b/packages/python-pexpect/python-pexpect.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        4.9.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Pexpect allows easy control of interactive console applications
 
 License:        ISC license
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 4.9.0-3
+- Bump release for EL10 rebuild
+
 * Mon Mar 24 2025 Odilon Sousa <osousa@redhat.com> - 4.9.0-2
 - Rebuild against python3.12
 

--- a/packages/python-productmd/python-productmd.spec
+++ b/packages/python-productmd/python-productmd.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.33
-Release:        8%{?dist}
+Release:        9%{?dist}
 Summary:        Product, compose and installation media metadata library
 
 License:        LGPLv2.1
@@ -50,6 +50,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.33-9
+- Bump release for EL10 rebuild
+
 * Mon Mar 31 2025 Odilon Sousa <osousa@redhat.com> - 1.33-8
 - Rebuild python-productmd against python3.12
 

--- a/packages/python-pyasn1-modules/python-pyasn1-modules.spec
+++ b/packages/python-pyasn1-modules/python-pyasn1-modules.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.4.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A collection of ASN.1-based protocols modules
 
 License:        BSD-2-Clause
@@ -53,6 +53,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.4.2-2
+- Bump release for EL10 rebuild
+
 * Sun Jun 15 2025 Foreman Packaging Automation <packaging@theforeman.org> - 0.4.2-1
 - Update to 0.4.2
 


### PR DESCRIPTION
Wave 16 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). 10 packages, one commit per package (`obal bump-release --changelog`).

No same-wave BuildRequires/Requires ordering issues — pre-flight audit confirmed none of these packages depend on each other. External Requires (six, markupsafe, attrs, pyrsistent, mdurl, et-xmlfile, opentelemetry_proto, opentelemetry_api, opentelemetry_semantic_conventions, typing-extensions, ptyprocess, pyasn1) are all already built in earlier merged waves/tiers.

Ref: theforeman/el10_rebuild#15