### PR TITLE
EL10 rebuild: python-rsa, python-ruamel-yaml, python-tuf, python-url-normalize, python-yarl

### DIFF
--- a/packages/python-rsa/python-rsa.spec
+++ b/packages/python-rsa/python-rsa.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        4.9.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Pure-Python RSA implementation
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -51,6 +51,9 @@ set -ex
 %{_bindir}/pyrsa-verify
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 4.9.1-2
+- Bump release for EL10 rebuild
+
 * Sun Apr 27 2025 Foreman Packaging Automation <packaging@theforeman.org> - 4.9.1-1
 - Update to 4.9.1
 

--- a/packages/python-ruamel-yaml/python-ruamel-yaml.spec
+++ b/packages/python-ruamel-yaml/python-ruamel-yaml.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        0.18.15
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order
 
 License:        MIT license
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.18.15-2
+- Bump release for EL10 rebuild
+
 * Thu Oct 02 2025 Foreman Packaging Automation <packaging@theforeman.org> - 0.18.15-1
 - Update to 0.18.15
 - Migrate to pyproject_wheel; remove gcc/libyaml-devel (pure Python)

--- a/packages/python-tuf/python-tuf.spec
+++ b/packages/python-tuf/python-tuf.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        7.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A Framework for Securing Software Update Systems
 
 License:        Apache-2.0 OR MIT
@@ -55,6 +55,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 7.0.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 7.0.0-1
 - Update to 7.0.0
 

--- a/packages/python-url-normalize/python-url-normalize.spec
+++ b/packages/python-url-normalize/python-url-normalize.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.2.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        URL normalization for Python
 
 License:        MIT
@@ -54,6 +54,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.2.1-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 01 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.2.1-1
 - Update to 2.2.1
 - Fix Source0: tarball uses underscores (url_normalize) since 2.x

--- a/packages/python-yarl/python-yarl.spec
+++ b/packages/python-yarl/python-yarl.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.23.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Yet another URL library
 BuildArch:      noarch
 
@@ -55,6 +55,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.23.0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.23.0-1
 - Update to 1.23.0
 


### PR DESCRIPTION
Wave 17 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). 5 packages, one commit per package (`obal bump-release --changelog`).

No same-wave BuildRequires/Requires ordering issues — pre-flight audit confirmed none of these packages depend on each other. External Requires (pyasn1, ruamel-yaml-clib, securesystemslib, urllib3, idna, multidict, propcache, expandvars) are all already built in earlier merged waves/tiers.

Ref: theforeman/el10_rebuild#15