### PR TITLE
EL10 rebuild: python-cryptography, python-gitpython, python-ldap, python-pycares, python-pydantic, python-rhsm, python-rich, python-tablib

### DIFF
--- a/packages/python-cryptography/python-cryptography.spec
+++ b/packages/python-cryptography/python-cryptography.spec
@@ -9,7 +9,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        46.0.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        cryptography is a package which provides cryptographic recipes and primitives to Python developers
 
 License:        BSD or Apache License, Version 2.0
@@ -70,6 +70,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 46.0.7-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 46.0.7-1
 - Update to 46.0.7
 - Exclude docs/, tests/, CHANGELOG.rst and CONTRIBUTING.rst installed by upstream into site-packages

--- a/packages/python-gitpython/python-gitpython.spec
+++ b/packages/python-gitpython/python-gitpython.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        3.1.50
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        GitPython is a python library used to interact with Git repositories
 
 License:        BSD
@@ -54,6 +54,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 3.1.50-2
+- Bump release for EL10 rebuild
+
 * Wed May 06 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.1.50-1
 - Update to 3.1.50
 

--- a/packages/python-ldap/python-ldap.spec
+++ b/packages/python-ldap/python-ldap.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        3.4.2
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Python modules for implementing LDAP clients
 
 License:        Python style
@@ -63,6 +63,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 3.4.2-7
+- Bump release for EL10 rebuild
+
 * Mon Mar 31 2025 Odilon Sousa <osousa@redhat.com> - 3.4.2-6
 - Rebuild against python3.12
 

--- a/packages/python-pycares/python-pycares.spec
+++ b/packages/python-pycares/python-pycares.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        5.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python interface for c-ares
 
 License:        MIT
@@ -58,6 +58,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 5.0.0-2
+- Bump release for EL10 rebuild
+
 * Sun Dec 14 2025 Foreman Packaging Automation <packaging@theforeman.org> - 5.0.0-1
 - Update to 5.0.0
 - Migrate to pyproject_wheel; fix PEP 639 license format in pyproject.toml

--- a/packages/python-pydantic/python-pydantic.spec
+++ b/packages/python-pydantic/python-pydantic.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.13.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Data validation using Python type hints
 
 License:        MIT
@@ -63,6 +63,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.13.4-2
+- Bump release for EL10 rebuild
+
 * Wed May 13 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.13.4-1
 - Update to 2.13.4
 - Update pydantic-core requirement to 2.46.4

--- a/packages/python-rhsm/python-rhsm-fix-py3-init-return.patch
+++ b/packages/python-rhsm/python-rhsm-fix-py3-init-return.patch
@@ -1,0 +1,26 @@
+--- a/src/certificate.c
++++ b/src/certificate.c
+@@ -610,7 +610,11 @@
+ 
+ 	certificate_x509_type.tp_new = PyType_GenericNew;
+ 	if (PyType_Ready (&certificate_x509_type) < 0) {
++		#if PY_MAJOR_VERSION >= 3
++		return NULL;
++		#else
+ 		return;
++		#endif
+ 	}
+ 
+ 	Py_INCREF (&certificate_x509_type);
+@@ -619,7 +623,11 @@
+ 
+     private_key_type.tp_new = PyType_GenericNew;
+ 	if (PyType_Ready (&private_key_type) < 0) {
++		#if PY_MAJOR_VERSION >= 3
++		return NULL;
++		#else
+ 		return;
++		#endif
+ 	}
+ 
+ 	Py_INCREF (&private_key_type);

--- a/packages/python-rhsm/python-rhsm.spec
+++ b/packages/python-rhsm/python-rhsm.spec
@@ -6,12 +6,13 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.19.2
-Release:        8%{?dist}
+Release:        9%{?dist}
 Summary:        A Python library to communicate with a Red Hat Unified Entitlement Platform
 
 License:        GPLv2
 URL:            http://fedorahosted.org/candlepin
 Source0:        %{pypi_source}
+Patch0:         python-rhsm-fix-py3-init-return.patch
 
 BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-setuptools
@@ -29,7 +30,7 @@ Requires:       python%{python3_pkgversion}-dateutil
 
 %prep
 set -ex
-%autosetup -n %{pypi_name}-%{version}
+%autosetup -n %{pypi_name}-%{version} -p1
 # Remove bundled egg-info
 rm -rf %{pypi_name}.egg-info
 
@@ -50,6 +51,12 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.19.2-9
+- Bump release for EL10 rebuild
+- Fix src/certificate.c: PyInit__certificate returned void on an error path,
+  which GCC on el10 treats as an error (return-type mismatch); patch it to
+  return NULL for Python 3 builds
+
 * Wed Apr 02 2025 Odilon Sousa <osousa@redhat.com> - 1.19.2-8
 - Rebuild against python3.12
 

--- a/packages/python-rich/python-rich.spec
+++ b/packages/python-rich/python-rich.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        15.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal
 
 License:        MIT
@@ -56,6 +56,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 15.0.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 15.0.0-1
 - Update to 15.0.0
 - Update markdown-it-py minimum to >= 2.2.0, pygments minimum to >= 2.13.0

--- a/packages/python-tablib/python-tablib.spec
+++ b/packages/python-tablib/python-tablib.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.9.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Format agnostic tabular data library (XLS, JSON, YAML, CSV)
 
 License:        MIT
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 3.9.0-3
+- Bump release for EL10 rebuild
+
 * Mon Jul 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.9.0-2
 - Drop xlrd and xlwt requirements
 


### PR DESCRIPTION
Wave 18 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). 8 packages, one commit per package (`obal bump-release --changelog`).

No same-wave BuildRequires/Requires ordering issues — pre-flight audit confirmed none of these packages depend on each other. External Requires (cffi, gitdb, typing-extensions, pyasn1-modules, idna, annotated-types, pydantic-core, typing-inspection, iniparse, dateutil, markdown-it-py, pygments, markuppy, odfpy, openpyxl, pyyaml) and BuildRequires (maturin, setuptools-rust) are all already built in earlier merged waves/tiers.

Ref: theforeman/el10_rebuild#15