### PR TITLE
EL10 rebuild: python-google-auth, python-pyOpenSSL, python-pyjwt, python-rfc3161-client, python-sigstore-models, python-sigstore-rekor-types

### DIFF
--- a/packages/python-google-auth/python-google-auth.spec
+++ b/packages/python-google-auth/python-google-auth.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.55.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Google Authentication Library
 
 License:        Apache 2.0
@@ -58,6 +58,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.55.2-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.55.2-1
 - Update to 2.55.2
 

--- a/packages/python-pyOpenSSL/python-pyOpenSSL.spec
+++ b/packages/python-pyOpenSSL/python-pyOpenSSL.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        26.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python wrapper module around the OpenSSL library
 
 License:        Apache License, Version 2.0
@@ -54,6 +54,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 26.2.0-2
+- Bump release for EL10 rebuild
+
 * Wed May 06 2026 Foreman Packaging Automation <packaging@theforeman.org> - 26.2.0-1
 - Update to 26.2.0
 

--- a/packages/python-pyjwt/python-pyjwt.spec
+++ b/packages/python-pyjwt/python-pyjwt.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{srcname}
 Version:        2.13.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        JSON Web Token implementation in Python
 
 License:        MIT
@@ -69,6 +69,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.13.0-2
+- Bump release for EL10 rebuild
+
 * Tue Jun 09 2026 Odilon Sousa <osousa@redhat.com> - 2.13.0-1
 - Update to 2.13.0 (fixes CVE-2026-48526)
 

--- a/packages/python-rfc3161-client/python-rfc3161-client.spec
+++ b/packages/python-rfc3161-client/python-rfc3161-client.spec
@@ -9,7 +9,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.0.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A client library for RFC 3161 Time-Stamp Protocol
 
 License:        Apache-2.0
@@ -65,5 +65,8 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.0.6-2
+- Bump release for EL10 rebuild
+
 * Tue Apr 14 2026 Odilon Sousa <osousa@redhat.com> - 1.0.6-1
 - Initial package.

--- a/packages/python-sigstore-models/python-sigstore-models.spec
+++ b/packages/python-sigstore-models/python-sigstore-models.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.0.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Data models for Sigstore
 
 License:        Apache-2.0
@@ -51,5 +51,8 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.0.6-2
+- Bump release for EL10 rebuild
+
 * Tue Apr 14 2026 Odilon Sousa <osousa@redhat.com> - 0.0.6-1
 - Initial package.

--- a/packages/python-sigstore-rekor-types/python-sigstore-rekor-types.spec
+++ b/packages/python-sigstore-rekor-types/python-sigstore-rekor-types.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.0.18
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Pydantic types for Sigstore Rekor
 
 License:        Apache-2.0
@@ -51,6 +51,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.0.18-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Odilon Sousa <osousa@redhat.com> - 0.0.18-1
 - Initial package.
 - Use pydantic+email metapackage to satisfy pydantic[email] extra


### PR DESCRIPTION
Wave 19 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). 6 packages, one commit per package (`obal bump-release --changelog`).

No same-wave BuildRequires/Requires ordering issues — pre-flight audit confirmed none of these packages depend on each other. External Requires (cryptography, cachetools, pyasn1-modules, rsa, typing-extensions, pydantic/pydantic+email) are all already built in earlier merged waves/tiers.

Note: wave 20 (`python-requests`) depends on `python-pyOpenSSL` in this wave, so it is intentionally not opened until this PR merges.

Ref: theforeman/el10_rebuild#15