### PR TITLE
EL10 rebuild: python-requests

### DIFF
--- a/packages/python-requests/python-requests.spec
+++ b/packages/python-requests/python-requests.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.33.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python HTTP for Humans
 
 License:        Apache 2.0
@@ -56,6 +56,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.33.1-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.33.1-1
 - Update to 2.33.1
 


### PR DESCRIPTION
Wave 20 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). 1 package (`obal bump-release --changelog`).

External Requires (certifi, charset-normalizer, idna, pyOpenSSL, urllib3) are all already built in earlier merged waves.

Note: wave 21 (galaxy-importer, google-api-core, opentelemetry_exporter_otlp_proto_http, pypi-simple, sigstore) all depend on this package, so it is intentionally not opened until this PR merges.

Ref: theforeman/el10_rebuild#15