### PR TITLE
EL10 rebuild: python-galaxy-importer, python-google-api-core, python-opentelemetry_exporter_otlp_proto_http, python-pypi-simple, python-sigstore

### DIFF
--- a/packages/python-galaxy-importer/python-galaxy-importer.spec
+++ b/packages/python-galaxy-importer/python-galaxy-importer.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.4.39
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Galaxy content importer
 
 License:        Apache-2.0
@@ -80,6 +80,9 @@ install -d -m 0755 %{buildroot}/%{_sysconfdir}/galaxy-importer/
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.4.39-2
+- Bump release for EL10 rebuild
+
 * Fri May 29 2026 Odilon Sousa <osousa@redhat.com> - 0.4.39-1
 - Update to 0.4.39
 - Relax packaging bound: < 25 → < 27 (upstream: packaging<27,>=23.2)

--- a/packages/python-google-api-core/python-google-api-core.spec
+++ b/packages/python-google-api-core/python-google-api-core.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.31.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Google API client core library
 
 License:        Apache 2.0
@@ -71,6 +71,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.31.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jun 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.31.0-1
 - Update to 2.31.0
 - Update googleapis-common-protos to >= 1.63.2, proto-plus to >= 1.24.0, protobuf to >= 5.29.6, requests to >= 2.33.0

--- a/packages/python-opentelemetry_exporter_otlp_proto_http/python-opentelemetry_exporter_otlp_proto_http.spec
+++ b/packages/python-opentelemetry_exporter_otlp_proto_http/python-opentelemetry_exporter_otlp_proto_http.spec
@@ -4,7 +4,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.40.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OpenTelemetry Collector Protobuf over HTTP Exporter
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -59,6 +59,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.40.0-2
+- Bump release for EL10 rebuild
+
 * Wed Apr 15 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1.40.0-1
 - Update to 1.40.0
 

--- a/packages/python-pypi-simple/python-pypi-simple.spec
+++ b/packages/python-pypi-simple/python-pypi-simple.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        1.8.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        PyPI Simple Repository API client library
 
 License:        MIT
@@ -52,6 +52,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.8.0-2
+- Bump release for EL10 rebuild
+
 * Wed Oct 22 2025 Foreman Packaging Automation <packaging@theforeman.org> - 1.8.0-1
 - Update to 1.8.0
 

--- a/packages/python-sigstore/python-sigstore.spec
+++ b/packages/python-sigstore/python-sigstore.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        4.4.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A tool for signing and verifying Python package distributions
 
 License:        Apache-2.0
@@ -72,6 +72,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 4.4.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 08 2026 Foreman Packaging Automation <packaging@theforeman.org> - 4.4.0-1
 - Update to 4.4.0
 


### PR DESCRIPTION
Wave 21 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). 5 packages, one commit per package (`obal bump-release --changelog`).

No same-wave BuildRequires/Requires ordering issues — pre-flight audit confirmed none of these packages depend on each other. External Requires (ansible-builder, attrs, flake8, markdown, nh3, semantic-version, google-auth, googleapis-common-protos, proto-plus, protobuf, deprecated, opentelemetry_api/proto/sdk/exporter_otlp_proto_common, beautifulsoup4, pydantic, mailbits, cryptography, id, pyasn1, pyjwt, pyOpenSSL, rich, rfc8785, rfc3161-client, sigstore-models, sigstore-rekor-types, tuf, platformdirs, requests) are all already built in earlier merged waves/tiers.

Note: wave 22 (google-cloud-core, pypi-attestations) depends on `python-sigstore` and `python-google-api-core` in this wave, so it is intentionally not opened until this PR merges.

Ref: theforeman/el10_rebuild#15