### PR TITLE
EL10 rebuild: python-google-cloud-core, python-pypi-attestations

### DIFF
--- a/packages/python-google-cloud-core/python-google-cloud-core.spec
+++ b/packages/python-google-cloud-core/python-google-cloud-core.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.6.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Google Cloud API client core library
 
 License:        Apache 2.0
@@ -59,6 +59,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.6.0-2
+- Bump release for EL10 rebuild
+
 * Sun May 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.6.0-1
 - Update to 2.6.0
 

--- a/packages/python-pypi-attestations/python-pypi-attestations.spec
+++ b/packages/python-pypi-attestations/python-pypi-attestations.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.0.28
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A library to convert between Sigstore Bundles and PEP-740 Attestation objects
 
 License:        Apache-2.0
@@ -66,5 +66,8 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.0.28-2
+- Bump release for EL10 rebuild
+
 * Tue Apr 14 2026 Odilon Sousa <osousa@redhat.com> - 0.0.28-1
 - Initial package.


### PR DESCRIPTION
Wave 22 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). 2 packages, one commit per package (`obal bump-release --changelog`).

No same-wave BuildRequires/Requires ordering issues — pre-flight audit confirmed neither package depends on the other. External Requires (google-api-core, google-auth, cryptography, packaging, pyasn1, pydantic, requests, rfc3986, sigstore, sigstore-models) are all already built in wave 21 or earlier.

Note: wave 23 (`python-google-cloud-storage`) depends on `python-google-cloud-core` in this wave, so it is intentionally not opened until this PR merges.

Ref: theforeman/el10_rebuild#15