### PR TITLE
EL10 rebuild: python-google-cloud-storage

### DIFF
--- a/packages/python-google-cloud-storage/python-google-cloud-storage.spec
+++ b/packages/python-google-cloud-storage/python-google-cloud-storage.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.12.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Google Cloud Storage API client library
 
 License:        Apache 2.0
@@ -64,6 +64,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 3.12.0-2
+- Bump release for EL10 rebuild
+
 * Sun Jun 28 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.12.0-1
 - Update to 3.12.0
 


### PR DESCRIPTION
Wave 23 of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). 1 package (`obal bump-release --changelog`).

External Requires (google-api-core, google-auth, google-cloud-core, google-crc32c, google-resumable-media, protobuf, requests) are all already built in wave 22 or earlier.

Ref: theforeman/el10_rebuild#15