### PR TITLE
EL10 rebuild: pulpcore-release

### DIFF
--- a/packages/pulpcore-release/pulpcore-release.spec
+++ b/packages/pulpcore-release/pulpcore-release.spec
@@ -5,7 +5,7 @@
 
 %global prereleasesource nightly
 %global prerelease %{?prereleasesource:.}%{?prereleasesource}
-%global release 1
+%global release 2
 
 Name:           pulpcore-release
 Version:        3.105
@@ -66,6 +66,9 @@ rm -rf %{buildroot}
 %config %{repo_dir}/*.repo
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 3.105-0.2.nightly
+- Bump release for EL10 rebuild
+
 * Wed Apr 29 2026 Odilon Sousa <osousa@redhat.com> - 3.105-0.1.nightly
 - Release pulpcore-release 3.105
 


### PR DESCRIPTION
Wave 24 (final wave) of the tier4_packages EL10 rebuild (theforeman/el10_rebuild#15). 1 package (`obal bump-release --changelog`).

`pulpcore-release` is the release-trigger meta-package with no dependency on any other tier4 package — it's a standalone yum-repo-definition RPM. Forced to the last wave regardless of the dependency graph per the original wave-planning note.

This is the last wave of tier4_packages. Once merged, all 208 tier4 packages are built for EL10 and the campaign moves to the pulpcore_packages tier (theforeman/el10_rebuild#16).

Ref: theforeman/el10_rebuild#15