### PR TITLE
EL10 rebuild: pulpcore-obsolete-packages, python-pulp-glue, python-pulpcore-client, python-pulp_manifest, python-pulp-rpm-client

### DIFF
--- a/comps/comps-pulpcore-el10.xml
+++ b/comps/comps-pulpcore-el10.xml
@@ -155,6 +155,7 @@
       <packagereq type="default">python3.12-json_stream_rs_tokenizer</packagereq>
       <packagereq type="default">python3.12-jsonschema</packagereq>
       <packagereq type="default">python3.12-keyring</packagereq>
+      <packagereq type="default">python3.12-lazy-imports</packagereq>
       <packagereq type="default">python3.12-ldap</packagereq>
       <packagereq type="default">python3.12-libcomps</packagereq>
       <packagereq type="default">python3.12-libcomps</packagereq>

--- a/comps/comps-pulpcore-el9.xml
+++ b/comps/comps-pulpcore-el9.xml
@@ -155,6 +155,7 @@
       <packagereq type="default">python3.12-json_stream_rs_tokenizer</packagereq>
       <packagereq type="default">python3.12-jsonschema</packagereq>
       <packagereq type="default">python3.12-keyring</packagereq>
+      <packagereq type="default">python3.12-lazy-imports</packagereq>
       <packagereq type="default">python3.12-ldap</packagereq>
       <packagereq type="default">python3.12-libcomps</packagereq>
       <packagereq type="default">python3.12-libcomps</packagereq>

--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -238,6 +238,7 @@ tier4_packages:
     python-inflection: {}
     python-isodate: {}
     python-jeepney: {}
+    python-lazy-imports: {}
     python-lxml: {}
     python-more-itertools: {}
     python-mypy-extensions: {}

--- a/packages/pulpcore-obsolete-packages/pulpcore-obsolete-packages.spec
+++ b/packages/pulpcore-obsolete-packages/pulpcore-obsolete-packages.spec
@@ -193,7 +193,6 @@ Obsoletes:      python3.12-django-prometheus < 2.1.0-9
 Obsoletes:      python3.12-django-storages < 1.14.6-2
 Obsoletes:      python3.12-enrich < 1.2.6-12
 Obsoletes:      python3.12-html5lib < 1.1-7
-Obsoletes:      python3.12-lazy-imports < 1.2.0-2
 Obsoletes:      python3.12-oauthlib < 3.1.1-7
 Obsoletes:      python3.12-python3-openid < 3.2.0-7
 Obsoletes:      python3.12-requests-oauthlib < 1.3.0-7
@@ -220,6 +219,9 @@ from the distribution for some reason.
 %changelog
 * Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.5.0-2
 - Bump release for EL10 rebuild
+- Drop erroneous Obsoletes for python3.12-lazy-imports: it is a real
+  Requires-Dist of python-pulpcore-client and python-pulp-rpm-client,
+  wrongly removed as unused in #2766; re-added at 1.2.0-2
 
 * Wed Jul 22 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.5.0-1
 - Add Obsoletes for packages removed during EL10 transition

--- a/packages/pulpcore-obsolete-packages/pulpcore-obsolete-packages.spec
+++ b/packages/pulpcore-obsolete-packages/pulpcore-obsolete-packages.spec
@@ -1,6 +1,6 @@
 Name: pulpcore-obsolete-packages
 Version: 1.5.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: MIT
 Summary: A package to obsolete retired packages
 URL: https://github.com/theforeman/pulpcore-packaging
@@ -218,6 +218,9 @@ from the distribution for some reason.
 %files
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 1.5.0-2
+- Bump release for EL10 rebuild
+
 * Wed Jul 22 2026 Zach Huntington-Meath <zhunting@redhat.com> - 1.5.0-1
 - Add Obsoletes for packages removed during EL10 transition
 

--- a/packages/python-lazy-imports/lazy_imports-1.2.0.tar.gz
+++ b/packages/python-lazy-imports/lazy_imports-1.2.0.tar.gz
@@ -1,0 +1,1 @@
+../../.git/annex/objects/26/2v/SHA256E-s24470--3c546b3c1e7c4bf62a07f897f6179d9feda6118e71ef6ecc47a339cab3d2e2d9.tar.gz/SHA256E-s24470--3c546b3c1e7c4bf62a07f897f6179d9feda6118e71ef6ecc47a339cab3d2e2d9.tar.gz

--- a/packages/python-lazy-imports/python-lazy-imports.spec
+++ b/packages/python-lazy-imports/python-lazy-imports.spec
@@ -1,0 +1,56 @@
+%global python3_pkgversion 3.12
+%global __python3 /usr/bin/python3.12
+
+# Created by pyp2rpm-3.3.3
+%global pypi_name lazy-imports
+%global src_name lazy_imports
+
+Name:           python%{python3_pkgversion}-%{pypi_name}
+Version:        1.2.0
+Release:        2%{?dist}
+Summary:        Tool to support lazy imports
+
+License:        Apache-2.0
+URL:            https://github.com/bachorp/lazy-imports
+Source0:        https://files.pythonhosted.org/packages/source/l/%{pypi_name}/%{src_name}-%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-pip
+BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-wheel
+BuildRequires:  pyproject-rpm-macros
+
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
+
+%description
+%{summary}
+
+
+%prep
+set -ex
+%autosetup -n %{src_name}-%{version}
+
+
+%build
+set -ex
+%pyproject_wheel
+
+
+%install
+set -ex
+%pyproject_install
+
+%files -n python%{python3_pkgversion}-%{pypi_name}
+%license LICENSE
+%doc README.md
+%{python3_sitelib}/%{src_name}
+%{python3_sitelib}/%{src_name}-%{version}.dist-info/
+
+
+%changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 1.2.0-2
+- Rebuild for EL10
+
+* Thu Mar 26 2026 Odilon Sousa <osousa@redhat.com> - 1.2.0-1
+- Initial package.

--- a/packages/python-pulp-glue/python-pulp-glue.spec
+++ b/packages/python-pulp-glue/python-pulp-glue.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.39.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Version agnostic glue library to talk to pulpcore's REST API
 
 License:        GPLv2+
@@ -63,6 +63,9 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.39.1-3
+- Bump release for EL10 rebuild
+
 * Fri May 29 2026 Odilon Sousa <osousa@redhat.com> - 0.39.1-2
 - Relax pydantic upper bound to < 2.14 (upstream pins <2.13; pydantic 2.13.x in staging)
 - Patch pyproject.toml in %%prep to match relaxed bound

--- a/packages/python-pulp-rpm-client/python-pulp-rpm-client.spec
+++ b/packages/python-pulp-rpm-client/python-pulp-rpm-client.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.35.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Pulp 3 API
 
 License:        GPLv2+
@@ -24,6 +24,8 @@ BuildRequires:  pyproject-rpm-macros
 
 
 Requires:       python%{python3_pkgversion}-dateutil
+Requires:       python%{python3_pkgversion}-lazy-imports >= 1
+Requires:       python%{python3_pkgversion}-lazy-imports < 2
 Requires:       python%{python3_pkgversion}-urllib3 >= 1.15
 
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
@@ -56,6 +58,12 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 3.35.3-2
+- Bump release for EL10 rebuild
+- Add explicit Requires on python-lazy-imports (real Requires-Dist per
+  upstream PKG-INFO, previously only picked up by RPM's automatic
+  dependency generator and missed when the package was pruned in #2766)
+
 * Tue Jun 09 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.35.3-1
 - Update to 3.35.3
 

--- a/packages/python-pulp_manifest/python-pulp_manifest.spec
+++ b/packages/python-pulp_manifest/python-pulp_manifest.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.0.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        Tool to generate a PULP_MANIFEST file for a given directory, so the directory can be recognized by Pulp
 
 License:        GPLv2+
@@ -54,6 +54,9 @@ set -ex
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 3.0.0-8
+- Bump release for EL10 rebuild
+
 * Tue Apr 08 2025 Odilon Sousa <osousa@redhat.com> - 3.0.0-7
 - Add obsoletes for python3.11 package
 

--- a/packages/python-pulpcore-client/python-pulpcore-client.spec
+++ b/packages/python-pulpcore-client/python-pulpcore-client.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.105.12
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Pulp 3 API
 
 License:        GPLv2+
@@ -22,6 +22,8 @@ BuildRequires:  python%{python3_pkgversion}-wheel
 BuildRequires:  pyproject-rpm-macros
 
 Requires:       python%{python3_pkgversion}-dateutil
+Requires:       python%{python3_pkgversion}-lazy-imports >= 1
+Requires:       python%{python3_pkgversion}-lazy-imports < 2
 Requires:       python%{python3_pkgversion}-six >= 1.10
 Requires:       python%{python3_pkgversion}-urllib3 >= 1.15
 
@@ -53,6 +55,12 @@ set -ex
 
 
 %changelog
+* Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 3.105.12-2
+- Bump release for EL10 rebuild
+- Add explicit Requires on python-lazy-imports (real Requires-Dist per
+  upstream PKG-INFO, previously only picked up by RPM's automatic
+  dependency generator and missed when the package was pruned in #2766)
+
 * Mon Jul 20 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.105.12-1
 - Update to 3.105.12
 


### PR DESCRIPTION
Wave 1 (layer 0) of the pulpcore_packages tier EL10 rebuild (theforeman/el10_rebuild#16). 5 packages, one commit per package (`obal bump-release --changelog`), plus a fix for a repoclosure failure this PR itself surfaced.

Re-audited the tier's dependency graph the same way as tier4 (theforeman/el10_rebuild#15): the issue's original wave 1 (10 packages) bundled `python-pulpcore` together with packages that `Requires: pulpcore` and `python-pulp-cli`/`python-pulp-cli-deb` together with their own dependencies — a same-wave violation. Replaced it with 3 dependency-layers:

- Layer 0 (this PR, no intra-tier deps): pulpcore-obsolete-packages, python-pulp-glue, python-pulpcore-client, python-pulp_manifest, python-pulp-rpm-client
- Layer 1 (next): python-pulp-glue-deb, python-pulp-cli, python-pulpcore
- Layer 2 (last): pulpcore-selinux, python-pulp-cli-deb, python-pulp-ansible, python-pulp-rpm, python-pulp-smart-proxy, python-pulp-container, python-pulp-deb, python-pulp-ostree, python-pulp-python

## Fix: python-lazy-imports repoclosure failure

Initial CI run failed repoclosure on `python3.12-pulpcore-client` — unresolved `python3.12dist(lazy-imports) >= 1, < 2`. `python-lazy-imports` is a real `Requires-Dist` of both `pulpcore-client` and `pulp-rpm-client` per their upstream PKG-INFO (precedent: #2404, when it was first added for the same reason). It was incorrectly deleted as "obsolete" in #2766, before the tier4 EL10 rebuild wave list was even generated — so this is its first EL10 verification build.

Fixed in this same PR:
- Re-added `packages/python-lazy-imports/` at 1.2.0-2 (Release bumped from the pre-deletion 1.2.0-1 to beat the stray `Obsoletes: python3.12-lazy-imports < 1.2.0-2` in `pulpcore-obsolete-packages`), registered in `package_manifest.yaml` (tier4_packages) and both `comps/comps-pulpcore-el9.xml` and `comps/comps-pulpcore-el10.xml`
- Dropped the erroneous Obsoletes line from `pulpcore-obsolete-packages` (already in this PR)
- Added explicit `Requires: python3.12-lazy-imports` to `python-pulpcore-client` and `python-pulp-rpm-client` (both already in this PR) so the dependency is statically visible and future cleanup automation doesn't drop it again by mistake

Ref: theforeman/el10_rebuild#16