### PR TITLE
EL10 rebuild: python-pulp-glue-deb, python-pulp-cli, python-pulpcore

### DIFF
--- a/packages/python-pulp-cli/python-pulp-cli.spec
+++ b/packages/python-pulp-cli/python-pulp-cli.spec
@@ -8,7 +8,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.39.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Command line interface to talk to pulpcore's REST API
 
 License:        GPLv2+
@@ -69,6 +69,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 0.39.1-3
+- Bump release for EL10 rebuild
+
 * Wed May 27 2026 Odilon Sousa <osousa@redhat.com> - 0.39.1-2
 - Remove stale Requires: python3.12-setuptools (not a runtime dep of pulp-cli 0.39.1)
 

--- a/packages/python-pulp-glue-deb/python-pulp-glue-deb.spec
+++ b/packages/python-pulp-glue-deb/python-pulp-glue-deb.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.4.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Version agnostic glue library to talk to pulpcore's REST API. (deb plugin)
 
 # Check if the automatically generated License and its spelling is correct for Fedora
@@ -53,6 +53,9 @@ set -ex
 %{python3_sitelib}/%{srcname}-%{version}.dist-info/
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 0.4.4-3
+- Bump release for EL10 rebuild
+
 * Fri May 29 2026 Odilon Sousa <osousa@redhat.com> - 0.4.4-2
 - Relax pulp-glue upper bound to < 0.40 (upstream: pulp-glue<0.40,>=0.23.2)
 

--- a/packages/python-pulpcore/python-pulpcore.spec
+++ b/packages/python-pulpcore/python-pulpcore.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.105.12
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Pulp Django Application and Related Modules
 
 License:        GPLv2+
@@ -175,6 +175,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 3.105.12-3
+- Bump release for EL10 rebuild
+
 * Mon Jul 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.105.12-2
 - Drop importlib-metadata requirement
 


### PR DESCRIPTION
Layer 1 of the `pulpcore_packages` tier build (theforeman/el10_rebuild#16) — bumps release to trigger a build/install verification on rhel-10-x86_64 alongside the existing rhel-9-x86_64 build.

Layer 0 (pulpcore-obsolete-packages, python-pulp-glue, python-pulpcore-client, python-pulp_manifest, python-pulp-rpm-client, #2871) is merged and built. This layer covers the three packages that depend only on layer 0's `python-pulp-glue`:

- python-pulp-glue-deb → python-pulp-glue
- python-pulp-cli → python-pulp-glue
- python-pulpcore → python-pulp-glue

None of these three packages depend on each other, so they're safe to bundle in one PR.

Ref: theforeman/el10_rebuild#16