### PR TITLE
EL10 rebuild: pulpcore-selinux, python-pulp-cli-deb, python-pulp-ansible, python-pulp-rpm, python-pulp-smart-proxy, python-pulp-container, python-pulp-deb, python-pulp-ostree, python-pulp-python

### DIFF
--- a/packages/pulpcore-selinux/pulpcore-selinux.spec
+++ b/packages/pulpcore-selinux/pulpcore-selinux.spec
@@ -6,7 +6,7 @@
 
 Name:           pulpcore-selinux
 Version:        2.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        SELinux policy for Pulp 3
 
 License:        GPL2+
@@ -85,6 +85,9 @@ fi
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 2.2.0-2
+- Bump release for EL10 rebuild
+
 * Wed Oct 08 2025 Evgeni Golov - 2.2.0-1
 - Release pulpcore-selinux 2.2.0
 

--- a/packages/python-pulp-ansible/python-pulp-ansible.spec
+++ b/packages/python-pulp-ansible/python-pulp-ansible.spec
@@ -8,7 +8,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.29.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 Epoch:          1
 Summary:        Pulp plugin to manage Ansible content, e.g. roles
 
@@ -70,6 +70,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 1:0.29.8-2
+- Bump release for EL10 rebuild
+
 * Wed May 06 2026 Foreman Packaging Automation <packaging@theforeman.org> - 1:0.29.8-1
 - Update to 0.29.8
 

--- a/packages/python-pulp-cli-deb/python-pulp-cli-deb.spec
+++ b/packages/python-pulp-cli-deb/python-pulp-cli-deb.spec
@@ -8,7 +8,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.4.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Command line interface (CLI) for Pulp's pulp_deb plugin.
 
 License:        GPLv2+
@@ -60,6 +60,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 0.4.4-3
+- Bump release for EL10 rebuild
+
 * Fri May 29 2026 Odilon Sousa <osousa@redhat.com> - 0.4.4-2
 - Relax pulp-cli upper bound to < 0.40 (upstream: pulp-cli<0.40,>=0.23.2)
 

--- a/packages/python-pulp-container/python-pulp-container.spec
+++ b/packages/python-pulp-container/python-pulp-container.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.27.10
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Container plugin for the Pulp Project
 
 License:        GPLv2+
@@ -62,6 +62,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 2.27.10-2
+- Bump release for EL10 rebuild
+
 * Tue Jun 09 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.27.10-1
 - Update to 2.27.10
 - Update pyjwt requirement to < 2.14 (upstream 2.27.10 allows pyjwt < 2.14)

--- a/packages/python-pulp-deb/python-pulp-deb.spec
+++ b/packages/python-pulp-deb/python-pulp-deb.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.8.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        pulp-deb plugin for the Pulp Project
 
 License:        GPLv2+
@@ -62,6 +62,9 @@ set -ex
 %{python3_sitelib}/pulp_deb-%{version}.dist-info/
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 3.8.2-2
+- Bump release for EL10 rebuild
+
 * Tue May 12 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.8.2-1
 - Update to 3.8.2
 

--- a/packages/python-pulp-ostree/python-pulp-ostree.spec
+++ b/packages/python-pulp-ostree/python-pulp-ostree.spec
@@ -9,7 +9,7 @@
  
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.6.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Ostree plugin for the Pulp Project
 
 License:        GPLv2+
@@ -65,6 +65,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 2.6.0-2
+- Bump release for EL10 rebuild
+
 * Tue Apr 14 2026 Foreman Packaging Automation <packaging@theforeman.org> - 2.6.0-1
 - Update to 2.6.0
 - Sync pulpcore upper bound with upstream 2.6.0: < 3.115

--- a/packages/python-pulp-python/python-pulp-python.spec
+++ b/packages/python-pulp-python/python-pulp-python.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.27.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        pulp-python plugin for the Pulp Project
 
 License:        GPLv2+
@@ -63,6 +63,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 3.27.5-2
+- Bump release for EL10 rebuild
+
 * Fri Jul 10 2026 Foreman Packaging Automation <packaging@theforeman.org> - 3.27.5-1
 - Update to 3.27.5
 

--- a/packages/python-pulp-rpm/python-pulp-rpm.spec
+++ b/packages/python-pulp-rpm/python-pulp-rpm.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        3.35.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        RPM plugin for the Pulp Project
 
 License:        GPLv2+
@@ -73,6 +73,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 3.35.3-3
+- Bump release for EL10 rebuild
+
 * Mon Jul 20 2026 Zach Huntington-Meath <zhunting@redhat.com> - 3.35.3-2
 - Drop importlib-resources requirement
 

--- a/packages/python-pulp-smart-proxy/python-pulp-smart-proxy.spec
+++ b/packages/python-pulp-smart-proxy/python-pulp-smart-proxy.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.4.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Smart Proxy plugin for the Pulp Project
 
 License:        GPLv2+
@@ -54,6 +54,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 0.4.0-2
+- Bump release for EL10 rebuild
+
 * Tue Apr 14 2026 Foreman Packaging Automation <packaging@theforeman.org> - 0.4.0-1
 - Update to 0.4.0
 - Sync pulpcore upper bound with upstream 0.4.0: < 3.106


### PR DESCRIPTION
Layer 2 of the `pulpcore_packages` tier build (theforeman/el10_rebuild#16) — bumps release to trigger a build/install verification on rhel-10-x86_64 alongside the existing rhel-9-x86_64 build.

Layer 1 (python-pulp-glue-deb, python-pulp-cli, python-pulpcore, #2872) is merged and built. This layer covers all remaining `pulpcore_packages`, each depending only on layer 0/1 packages:

- pulpcore-selinux → pulpcore
- python-pulp-cli-deb → pulp-cli + pulp-glue-deb
- python-pulp-ansible → pulpcore
- python-pulp-rpm → pulpcore
- python-pulp-smart-proxy → pulpcore
- python-pulp-container → pulpcore
- python-pulp-deb → pulpcore
- python-pulp-ostree → pulpcore
- python-pulp-python → pulpcore

None of these 9 packages depend on each other, so they're safe to bundle in one PR. This closes out the `pulpcore_packages` tier — once this merges, every package in `package_manifest.yaml` is built for EL10.

Ref: theforeman/el10_rebuild#16