### PR TITLE
Re-enable EL10 repoclosure in package_manifest.yaml

### DIFF
--- a/package_manifest.yaml
+++ b/package_manifest.yaml
@@ -18,11 +18,17 @@ packages:
     repoclosure_target_repos:
       el9:
         - "el9-pulpcore-{{ pulpcore_version }}-staging"
+      el10:
+        - "el10-pulpcore-{{ pulpcore_version }}-staging"
     repoclosure_lookaside_repos:
       el9:
         - el9-baseos
         - el9-appstream
         - el9-crb
+      el10:
+        - el10-baseos
+        - el10-appstream
+        - el10-crb
   children:
     buildroot_packages: {}
     tier1_packages: {}
@@ -76,6 +82,17 @@ repoclosures:
           - el9-appstream
           - el9-crb
           - el9-foreman-plugins-nightly
+    pulpcore-staging-repoclosure-el10:
+      repoclosure_target_repos:
+        el10:
+          - "el10-pulpcore-{{ pulpcore_version }}-staging"
+      repoclosure_target_dist: el10
+      repoclosure_lookaside_repos:
+        el10:
+          - el10-baseos
+          - el10-appstream
+          - el10-crb
+          - el10-foreman-plugins-nightly
 
 buildroot_packages:
   hosts:


### PR DESCRIPTION
Restores the `el10` repoclosure entries removed in #2788 while the EL10 rebuild was in progress (the target repo was empty at the time, so repoclosure failed on every PR).

theforeman/el10_rebuild#16 (the `pulpcore_packages` tier, last remaining group) is now merged — every package in `package_manifest.yaml` (buildroot, tier1-4, pulpcore_packages) builds for EL10. This restores:

- `repoclosure_target_repos.el10` / `repoclosure_lookaside_repos.el10` under `packages.vars`
- the `pulpcore-staging-repoclosure-el10` host under `repoclosures`

Note: this alone doesn't turn EL10 repoclosure back on in CI — the shared Jenkins pipeline (`theforeman/jenkins-jobs` PR #591) still has `skip_repoclosure_dists = ['el10']` in `pipelines/test/rpm_copr_packaging.groovy`, which applies to both pulpcore-packaging and foreman-packaging. That flag needs its own follow-up since foreman-packaging's EL10 rebuild isn't done yet (theforeman/el10_rebuild#8) — flipping it now would also turn on EL10 repoclosure for every foreman-packaging PR.

Ref: theforeman/el10_rebuild#17