### PR TITLE
Fix EL10 gap: python-diff-match-patch

### DIFF
--- a/packages/python-diff-match-patch/python-diff-match-patch.spec
+++ b/packages/python-diff-match-patch/python-diff-match-patch.spec
@@ -7,7 +7,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        20241021
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Repackaging of Google's Diff Match and Patch libraries
 
 License:        Apache
@@ -47,6 +47,9 @@ set -ex
 
 
 %changelog
+* Fri Jul 31 2026 Odilon Sousa <osousa@redhat.com> - 20241021-3
+- Bump release for EL10 rebuild
+
 * Mon Mar 31 2025 Odilon Sousa <osousa@redhat.com> - 20241021-2
 - Rebuild against python3.12
 


### PR DESCRIPTION
Found via a real EL10 install failure in theforeman/puppet-pulpcore CI:
https://github.com/theforeman/puppet-pulpcore/actions/runs/30661608422/job/91258977370

```
Problem: package python3.12-pulpcore-3.105.12-3.el10.noarch from pulpcore requires
  (python3.12dist(django-import-export) < 5~~ with python3.12dist(django-import-export) >= 2.9),
  but none of the providers can be installed
 - nothing provides python3.12-diff-match-patch needed by python3.12-django-import-export-4.4.1-2.el10.noarch
```

**python-diff-match-patch** — listed in `tier4_packages`, but its COPR package (`python3.12-diff-match-patch`) was only ever built for `rhel-9-x86_64`. Slipped through all 24 tier4 waves. Bumped release to trigger an EL10 build.

While sweeping every package in `package_manifest.yaml` against COPR's actual latest-succeeded-build chroots (resolving each package's real RPM `Name:`, not the source directory name) to check for other silent gaps like this one, also found:

- **python-lxml** — still hardcoded `%global python3_pkgversion 3.11`, so `python3.12-lxml` never existed here, breaking `python3.12-aiohttp-xmlrpc`'s plain `Requires: python3.12-lxml` (a dependency of `python-pulp-rpm` and `python-bandersnatch`). `python3.12-lxml` is already provided natively by CentOS Stream 9 and 10 (confirmed: `python3.12-lxml = 5.2.1-2.el10`), so the plan is to drop our custom build entirely rather than rebuild it — tracked separately, not part of this PR.
- Ten other packages (`python-ecdsa`, `python-future`, `python-colorama`, `python-commonmark`, `python-contextlib2`, `python-dataclasses`, `python-idna-ssl`, `python-pycryptodomex`, `python-pyjwkest`, `python-toml`, `python-types-cryptography`, `postgresql-debversion`, `postgresql-evr`) also never got past `rhel-8-x86_64`, but aren't referenced by any current spec and mostly already have their own `Obsoletes` entries from the python 3.11→3.12 transition — likely retired packages whose manifest entries were never cleaned up. Not touched here.

Ref: theforeman/el10_rebuild#17