### PR TITLE
Relax python-galaxy-importer attrs bound for EL10

### DIFF
--- a/packages/python-galaxy-importer/python-galaxy-importer.spec
+++ b/packages/python-galaxy-importer/python-galaxy-importer.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        0.4.39
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Galaxy content importer
 
 License:        Apache-2.0
@@ -24,7 +24,7 @@ Requires:       ansible-lint <= 26.4.0
 Requires:       ansible-lint >= 6.2.2
 Requires:       python%{python3_pkgversion}-ansible-builder < 4.0
 Requires:       python%{python3_pkgversion}-ansible-builder >= 1.2.0
-Requires:       python%{python3_pkgversion}-attrs < 23
+Requires:       python%{python3_pkgversion}-attrs < 24
 Requires:       python%{python3_pkgversion}-attrs >= 21.4.0
 Requires:       python%{python3_pkgversion}-flake8 < 7
 Requires:       python%{python3_pkgversion}-flake8 >= 5.0.0
@@ -59,6 +59,10 @@ rm -rf %{pypi_name}.egg-info
 
 sed -i -E '/\s+ansible($|-core|-lint)/d' setup.cfg
 
+# Relax attrs bound: < 23 -> < 24, matching the spec Requires override above
+# (ansible/galaxy-importer#438, not yet merged/released)
+sed -i '/attrs/s/<23/<24/' setup.cfg
+
 
 %build
 set -ex
@@ -80,6 +84,11 @@ install -d -m 0755 %{buildroot}/%{_sysconfdir}/galaxy-importer/
 
 
 %changelog
+* Mon Aug 03 2026 Odilon Sousa <osousa@redhat.com> - 0.4.39-3
+- Relax attrs bound: < 23 -> < 24, to unblock EL10 install (baseos python3-attrs
+  obsoletes our attrs < 23.2.0-7; overrides upstream's conservative pin ahead of
+  ansible/galaxy-importer#438 'Allow attrs < 24')
+
 * Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 0.4.39-2
 - Bump release for EL10 rebuild
 


### PR DESCRIPTION
EL10's base-OS `python3-attrs` (23.2.0-6/-7) carries `Obsoletes: python3.12-attrs < 23.2.0-{6,7}.el10`, which conflicts with `python-galaxy-importer`'s upstream-inherited pin `Requires: python3.12-attrs < 23`. This blocks `python-pulp-ansible` install on EL10:

```
Error:
 Problem: problem with installed package python3-attrs-23.2.0-7.el10.noarch
  - installed package python3-attrs-23.2.0-7.el10.noarch obsoletes python3.12-attrs < 23.2.0-7.el10 provided by python3.12-attrs-22.2.0-3.el10.noarch from pulpcore
  - package python3.12-galaxy-importer-0.4.39-2.el10.noarch from pulpcore requires (python3.12dist(attrs) < 23~~ with python3.12dist(attrs) >= 21.4), but none of the providers can be installed
  ...
```

Upstream has an open fix, [ansible/galaxy-importer#438 "Allow attrs < 24"](https://github.com/ansible/galaxy-importer/pull/438), but it isn't merged/released yet. This PR applies the same relaxation locally as a documented override ahead of that release:

- Bump `Requires: python3.12-attrs < 23` to `< 24` in the spec
- Add a `%prep` sed to relax the same bound in `setup.cfg` (`attrs>=21.4.0,<23` -> `<24`), since RPM's automatic python dependency generator also emits a versioned `python3.12dist(attrs)` requirement from the package's own metadata — the spec-only edit alone wasn't sufficient

Scoped to `<24` (not unbounded) since attrs 24.x has real breaking changes vs 23.x and galaxy-importer hasn't been verified against it.

No other packaged spec pins an attrs upper bound, so this is self-contained.

Verified via `obal scratch python-galaxy-importer` — both `rhel-9-x86_64` (10807284) and `rhel-10-x86_64` (10807285) chroots succeeded.

Ref: theforeman/el10_rebuild#26