### PR TITLE
Add EL10 repo definitions to repoclosure config

### DIFF
--- a/repoclosure/yum.conf
+++ b/repoclosure/yum.conf
@@ -36,3 +36,28 @@ baseurl=https://stagingyum.theforeman.org/pulpcore/nightly/el9/x86_64/
 name=Foreman plugins nightly EL9
 baseurl=https://yum.theforeman.org/plugins/nightly/el9/x86_64/
 enabled=1
+
+[el10-baseos]
+name=CentOS Stream 10 - BaseOS
+metalink=https://mirrors.centos.org/metalink?repo=centos-baseos-10-stream&arch=x86_64&protocol=https,http
+enabled=1
+
+[el10-appstream]
+name=CentOS Stream 10 - AppStream
+metalink=https://mirrors.centos.org/metalink?repo=centos-appstream-10-stream&arch=x86_64&protocol=https,http
+enabled=1
+
+[el10-crb]
+name=CentOS Stream 10 - CRB
+metalink=https://mirrors.centos.org/metalink?repo=centos-crb-10-stream&arch=x86_64&protocol=https,http
+enabled=1
+
+[el10-pulpcore-nightly-staging]
+name=pulpcore nightly EL10
+baseurl=https://stagingyum.theforeman.org/pulpcore/nightly/el10/x86_64/
+
+[el10-foreman-plugins-nightly]
+name=Foreman plugins nightly EL10 (COPR staging, no el10 tree on yum.theforeman.org yet)
+baseurl=https://download.copr.fedorainfracloud.org/results/@theforeman/plugins-nightly-staging/rhel-10-x86_64/
+gpgcheck=0
+enabled=1


### PR DESCRIPTION
Jenkins repoclosure fails on EL10:

```
command: dnf repoclosure --refresh --newest --best --config /tmp/ansible.../yum.conf
    --arch noarch --arch x86_64 --check el10-pulpcore-nightly-staging --repo el10-pulpcore-nightly-staging
    --repo el10-baseos --repo el10-appstream --repo el10-crb --repo el10-foreman-plugins-nightly
msg: Repoclosure failed
output: |-
    Unable to detect release version (use '--releasever' to specify release version)
    Error: Unknown repo: 'el10-pulpcore-nightly-staging'
```

`repoclosure/yum.conf` only defines `el9-*` repo sections. This adds the matching EL10 ones:

- `el10-baseos`, `el10-appstream`, `el10-crb` — CentOS Stream 10 metalinks, mirroring the el9 sections
- `el10-pulpcore-nightly-staging` — `stagingyum.theforeman.org/pulpcore/nightly/el10/x86_64/`
- `el10-foreman-plugins-nightly` — `yum.theforeman.org/plugins/nightly/el10/` doesn't exist yet (404, only `el9` is published there), so this points at the COPR staging mirror (`@theforeman/plugins-nightly-staging`, rhel-10-x86_64) instead, with `gpgcheck=0` for now until that's sorted out

Verified locally: `dnf repoclosure` against these five repos loads cleanly (exit 0, no unresolved deps).

Ref: theforeman/el10_rebuild#20