### PR TITLE
Add Obsoletes/Provides for python3-cryptography and python3-requests on RHEL 10

### DIFF
--- a/comps/comps-pulpcore-el10.xml
+++ b/comps/comps-pulpcore-el10.xml
@@ -25,6 +25,7 @@
       <packagereq type="default">pulpcore-selinux</packagereq>
       <packagereq type="default">pyproject-rpm-macros</packagereq>
       <packagereq type="default">python3-createrepo_c</packagereq>
+      <packagereq type="default">python3-cryptography</packagereq>
       <packagereq type="default">python3-libcomps</packagereq>
       <packagereq type="default">python3.12-SecretStorage</packagereq>
       <packagereq type="default">python3.12-aiodns</packagereq>

--- a/comps/comps-pulpcore-el10.xml
+++ b/comps/comps-pulpcore-el10.xml
@@ -27,6 +27,7 @@
       <packagereq type="default">python3-createrepo_c</packagereq>
       <packagereq type="default">python3-cryptography</packagereq>
       <packagereq type="default">python3-libcomps</packagereq>
+      <packagereq type="default">python3-requests</packagereq>
       <packagereq type="default">python3.12-SecretStorage</packagereq>
       <packagereq type="default">python3.12-aiodns</packagereq>
       <packagereq type="default">python3.12-aiofiles</packagereq>

--- a/packages/python-cryptography/python-cryptography.spec
+++ b/packages/python-cryptography/python-cryptography.spec
@@ -9,7 +9,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        46.0.7
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        cryptography is a package which provides cryptographic recipes and primitives to Python developers
 
 License:        BSD or Apache License, Version 2.0
@@ -34,6 +34,12 @@ BuildRequires:  openssl-devel
 BuildRequires:  gcc
 
 Requires:       python%{python3_pkgversion}-cffi >= 2.0.0
+
+%if 0%{?rhel} >= 10
+Obsoletes: python3-%{pypi_name} < %{version}-%{release}
+Provides:  python3-%{pypi_name} = %{version}-%{release}
+Provides:  python3-%{pypi_name}%{?_isa} = %{version}-%{release}
+%endif
 
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
@@ -70,6 +76,10 @@ set -ex
 
 
 %changelog
+* Mon Aug 24 2026 Odilon Sousa <osousa@redhat.com> - 46.0.7-3
+- Add Obsoletes/Provides for python3-cryptography on RHEL 10
+- Prevent file conflicts with the BaseOS-provided package
+
 * Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 46.0.7-2
 - Bump release for EL10 rebuild
 

--- a/packages/python-requests/python-requests.spec
+++ b/packages/python-requests/python-requests.spec
@@ -6,7 +6,7 @@
 
 Name:           python%{python3_pkgversion}-%{pypi_name}
 Version:        2.33.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Python HTTP for Humans
 
 License:        Apache 2.0
@@ -29,6 +29,11 @@ Requires:       python%{python3_pkgversion}-idna >= 2.5
 Requires:       python%{python3_pkgversion}-pyOpenSSL >= 0.14
 Requires:       python%{python3_pkgversion}-urllib3 < 3
 Requires:       python%{python3_pkgversion}-urllib3 >= 1.21.1
+
+%if 0%{?rhel} >= 10
+Obsoletes: python3-%{pypi_name} < %{version}-%{release}
+Provides:  python3-%{pypi_name} = %{version}-%{release}
+%endif
 
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
@@ -56,6 +61,10 @@ set -ex
 
 
 %changelog
+* Mon Aug 24 2026 Odilon Sousa <osousa@redhat.com> - 2.33.1-3
+- Add Obsoletes/Provides for python3-requests on RHEL 10
+- Prevent file conflicts with the BaseOS-provided package
+
 * Thu Jul 30 2026 Odilon Sousa <osousa@redhat.com> - 2.33.1-2
 - Bump release for EL10 rebuild
 


### PR DESCRIPTION
## Problem

Installing Satellite container images on RHEL 10 fails during `satellitectl pull-images`'s `pre_install` role with an RPM transaction conflict:

```
Unknown Error occurred: Transaction test error:
  file /usr/lib64/python3.12/site-packages/cryptography/... from install of
  python3-cryptography-43.0.0-4.el10.x86_64 conflicts with file from package
  python3.12-cryptography-46.0.7-2.el10pc.x86_64
```

`foremanctl`'s `pre_install` role requests `python3-cryptography` (and `python3-requests`) by the plain, unversioned name. On RHEL 10, `python3` is `python3.12`, and this repo builds both packages under the versioned `python312-*` name via a hardcoded `%global python3_pkgversion 3.12`, so both names resolve to the same physical site-packages path. When a host has both installed, dnf reports a hard file conflict rather than resolving versions across two differently-named packages.

## Fix

Add the same inline `Obsoletes`/`Provides` pattern already used by `python-ldap.spec` for `python3-pyldap`, gated to `%if 0%{?rhel} >= 10` so RHEL 9 (where `python3-cryptography`/`python3-requests` are distinct, legitimate python3.9 packages) is untouched.

Obsoletes are versioned against `%{version}-%{release}`, matching this repo's convention.

`python-requests` has the identical shape (hardcoded `python3.12` build, requested as plain `python3-requests` by the same `pre_install` role) — no live conflict has been hit for it yet, but the collision risk is identical, so it's fixed in the same pass.

Also added `python3-cryptography` and `python3-requests` to `comps/comps-pulpcore-el10.xml` so the published repo group metadata includes the unversioned names these packages now provide/obsolete on RHEL 10 (matching the existing `python3-createrepo_c`/`python3-libcomps` entries already there).

Other packages in that `pre_install` list (`python3-libsemanage`, `python3-psycopg2`, `python3-requests-oauthlib`) aren't independently built under a versioned name here or in `foreman-packaging`, so they're not at risk of this specific collision.