### PR TITLE
Update rpmdevtools links from pagure to codeberg

### DIFF
--- a/.github/workflows/generate-package-list.yml
+++ b/.github/workflows/generate-package-list.yml
@@ -71,9 +71,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install -y --no-install-recommends python3-rpm rpm git-annex python3-semver
-          sudo curl --create-dirs -o /usr/local/bin/spectool https://pagure.io/rpmdevtools/raw/26a8abc746fba9c0b32eb899b96c92841a37855a/f/spectool.in
-          sudo curl --create-dirs -o /usr/local/bin/rpmdev-bumpspec https://pagure.io/rpmdevtools/raw/6f387c1deaa5cbed770310e288abde04b17421dc/f/rpmdev-bumpspec
-          sudo curl --create-dirs -o /usr/local/bin/rpmdev-vercmp https://pagure.io/rpmdevtools/raw/79740e6f1881e399b0b4340a8090dd5adc91a4ea/f/rpmdev-vercmp
+          sudo curl --create-dirs -o /usr/local/bin/spectool https://codeberg.org/rpm-community/rpmdevtools/raw/commit/739cb055688c455d5dabf74d48068a655d153ad6/spectool.in
+          sudo curl --create-dirs -o /usr/local/bin/rpmdev-bumpspec https://codeberg.org/rpm-community/rpmdevtools/raw/commit/30eca1b7a06a2df5bbfa3bfd6a4c89c19c6ebd60/rpmdev-bumpspec
+          sudo curl --create-dirs -o /usr/local/bin/rpmdev-vercmp https://codeberg.org/rpm-community/rpmdevtools/raw/commit/79740e6f1881e399b0b4340a8090dd5adc91a4ea/rpmdev-vercmp
           printf '#!/bin/bash\necho "$GIT_AUTHOR_NAME <$GIT_AUTHOR_EMAIL>"' | sudo tee /usr/local/bin/rpmdev-packager
           sudo chmod +x /usr/local/bin/spectool /usr/local/bin/rpmdev-*
       - name: Initialize git annex

--- a/.github/workflows/requirement-check.yml
+++ b/.github/workflows/requirement-check.yml
@@ -27,9 +27,9 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y --no-install-recommends python3-rpm rpm git-annex python3-semver
-        sudo curl --create-dirs -o /usr/local/bin/spectool https://pagure.io/rpmdevtools/raw/26a8abc746fba9c0b32eb899b96c92841a37855a/f/spectool.in
-        sudo curl --create-dirs -o /usr/local/bin/rpmdev-bumpspec https://pagure.io/rpmdevtools/raw/6f387c1deaa5cbed770310e288abde04b17421dc/f/rpmdev-bumpspec
-        sudo curl --create-dirs -o /usr/local/bin/rpmdev-vercmp https://pagure.io/rpmdevtools/raw/79740e6f1881e399b0b4340a8090dd5adc91a4ea/f/rpmdev-vercmp
+        sudo curl --create-dirs -o /usr/local/bin/spectool https://codeberg.org/rpm-community/rpmdevtools/raw/commit/739cb055688c455d5dabf74d48068a655d153ad6/spectool.in
+        sudo curl --create-dirs -o /usr/local/bin/rpmdev-bumpspec https://codeberg.org/rpm-community/rpmdevtools/raw/commit/30eca1b7a06a2df5bbfa3bfd6a4c89c19c6ebd60/rpmdev-bumpspec
+        sudo curl --create-dirs -o /usr/local/bin/rpmdev-vercmp https://codeberg.org/rpm-community/rpmdevtools/raw/commit/79740e6f1881e399b0b4340a8090dd5adc91a4ea/rpmdev-vercmp
         printf '#!/bin/bash\necho "$GIT_AUTHOR_NAME <$GIT_AUTHOR_EMAIL>"' | sudo tee /usr/local/bin/rpmdev-packager
         sudo chmod +x /usr/local/bin/spectool /usr/local/bin/rpmdev-*
     - name: Sort Updated Libs

--- a/.github/workflows/update-pulp-packages.yml
+++ b/.github/workflows/update-pulp-packages.yml
@@ -47,9 +47,9 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y --no-install-recommends python3-rpm rpm git-annex python3-semver
-        sudo curl --create-dirs -o /usr/local/bin/spectool https://pagure.io/rpmdevtools/raw/26a8abc746fba9c0b32eb899b96c92841a37855a/f/spectool.in
-        sudo curl --create-dirs -o /usr/local/bin/rpmdev-bumpspec https://pagure.io/rpmdevtools/raw/6f387c1deaa5cbed770310e288abde04b17421dc/f/rpmdev-bumpspec
-        sudo curl --create-dirs -o /usr/local/bin/rpmdev-vercmp https://pagure.io/rpmdevtools/raw/79740e6f1881e399b0b4340a8090dd5adc91a4ea/f/rpmdev-vercmp
+        sudo curl --create-dirs -o /usr/local/bin/spectool https://codeberg.org/rpm-community/rpmdevtools/raw/commit/739cb055688c455d5dabf74d48068a655d153ad6/spectool.in
+        sudo curl --create-dirs -o /usr/local/bin/rpmdev-bumpspec https://codeberg.org/rpm-community/rpmdevtools/raw/commit/30eca1b7a06a2df5bbfa3bfd6a4c89c19c6ebd60/rpmdev-bumpspec
+        sudo curl --create-dirs -o /usr/local/bin/rpmdev-vercmp https://codeberg.org/rpm-community/rpmdevtools/raw/commit/79740e6f1881e399b0b4340a8090dd5adc91a4ea/rpmdev-vercmp
         printf '#!/bin/bash\necho "$GIT_AUTHOR_NAME <$GIT_AUTHOR_EMAIL>"' | sudo tee /usr/local/bin/rpmdev-packager
         sudo chmod +x /usr/local/bin/spectool /usr/local/bin/rpmdev-*
         git config --global user.name "$GIT_AUTHOR_NAME"


### PR DESCRIPTION
rpmdevtools moved from pagure.io to codeberg.org, breaking CI in every workflow that curls `spectool.in`, `rpmdev-bumpspec`, or `rpmdev-vercmp` directly from a pinned commit on the old pagure repo (`generate-package-list.yml`, `requirement-check.yml`, `update-pulp-packages.yml`).

Point at the equivalent commit on the new `codeberg.org/rpm-community/rpmdevtools` mirror for each file — same commits already used by the identical fix in foreman-packaging for `spectool.in`/`rpmdev-bumpspec`; `rpmdev-vercmp` hasn't been touched since the migration so its commit hash is unchanged, just the host.

Same fix as theforeman/foreman-packaging@fd9ab5b42626636d7ca93463631b742f35ed5086